### PR TITLE
Revise language around gender in QC tools page

### DIFF
--- a/content/learn/data-submitters/qc-data.md
+++ b/content/learn/data-submitters/qc-data.md
@@ -53,9 +53,9 @@ The output from the QC aggregator is a QC summary results TSV file.  Data submit
 </figure>
 
 ## Additional Resources - Upcoming AnVIL Tools
-AnVIL Data Processing Working Group is evaluating two tools to add to the submission process to calculate gender and compare that to reported gender.  The goal is to identify at a cohort level any major issues seen between the genomic data and the reported phenotype data.
+AnVIL Data Processing Working Group is evaluating two tools to add to the submission process to estimate genetic sex and compare that to reported sex.  The goal is to identify at a cohort level any major issues seen between the genomic data and the reported phenotype data (e.g., large numbers of mismatches indicating errors in phenotype coding or in mapping samples to participants).
 ### Exome QC Processing
 _Coming soon_
-### Gender Check
+### Sex Check
 _Coming soon_
 


### PR DESCRIPTION
Replace the term "gender" with "sex" in QC descriptions, as gender reflects social identity while sex is a biological characteristic. QC tools cannot calculate gender, but they can estimate genetic sex. I use the term "estimate" rather than "calculate" here because variation in sex chromosome copy number (e.g., XXY, XO, somatic mosaicism) means that genetic sex prediction is not 100% accurate, although it is an excellent tool for detecting major cohort-level issues as this page notes.