### PR TITLE
Replace help.md Community Slack with Discourse

### DIFF
--- a/content/help/help.md
+++ b/content/help/help.md
@@ -1,15 +1,13 @@
 ---
 title: "AnVIL Help desk"
 author: "AnVIL"
-description: "Contact us on the AnVIL Community Slack channel email our help desk."
+description: "Contact us on the AnVIL Discourse or email our help desk."
 ---
-
-#Help
 
 ## AnVIL
 
 To ask a question or provide feedback, please feel free to reach out to us on the
-[AnVIL Community on Slack]( https://join.slack.com/t/anvil-community/shared_invite/zt-hsyfam1w-LXlCv~3vNLSfDj~qNd5uBg) or 
+[AnVIL Discourse](https://help.anvilproject.org/) or 
 email our [help desk](mailto:help@lists.anvilproject.org). 
 
 Refer to the following table for platform specific help.


### PR DESCRIPTION
Encourage users to post questions in the Discourse rather than the Community Slack (use Slack more for synchronous, live events). Updated content and page metadata.
Also remove "Help" page header1 because it is redundant with headline title.