### PR TITLE
Add tooltip highlighting to data ingestion chart

### DIFF
--- a/src/components/data-ingestion-chart/data-ingestion-chart.tsx
+++ b/src/components/data-ingestion-chart/data-ingestion-chart.tsx
@@ -223,20 +223,21 @@ function getChartOptions(hoverIndex: React.MutableRefObject<null | number>) {
 }
 
 function getParentSeriesIndex(initPart: BasicEchartsPart | undefined) {
+  /* eslint-disable no-underscore-dangle */
+
   let part = initPart;
 
-  // eslint-disable-next-line no-underscore-dangle
   while (part && part?.__ecComponentInfo?.mainType !== "series") {
     part = part.parent;
   }
 
-  // eslint-disable-next-line no-underscore-dangle
   if (part?.__ecComponentInfo?.mainType === "series") {
-    // eslint-disable-next-line no-underscore-dangle
     return part.__ecComponentInfo.index;
   }
 
   return null;
+
+  /* eslint-enable no-underscore-dangle */
 }
 
 const DataIngestionChart: FC = (): JSX.Element => {

--- a/src/components/data-ingestion-chart/data-ingestion-chart.tsx
+++ b/src/components/data-ingestion-chart/data-ingestion-chart.tsx
@@ -37,13 +37,11 @@ type TooltipSeriesInfo = {
 type BasicEchartsPart = {
   // Simplified type for ECharts graph components
   // Only the properties necessary to find the parent series's type and index
-  parent: BasicEchartsPart | undefined;
-  __ecComponentInfo:
-    | {
-        mainType: string;
-        index: number;
-      }
-    | undefined;
+  parent?: BasicEchartsPart;
+  __ecComponentInfo?: {
+    mainType: string;
+    index: number;
+  };
 };
 
 function fixDecimalPlaces(n: number, places: number) {
@@ -222,7 +220,7 @@ function getChartOptions(hoverIndex: React.MutableRefObject<null | number>) {
   };
 }
 
-function getParentSeriesIndex(initPart: BasicEchartsPart | undefined) {
+function getParentSeriesIndex(initPart?: BasicEchartsPart) {
   /* eslint-disable no-underscore-dangle */
 
   let part = initPart;
@@ -241,20 +239,16 @@ function getParentSeriesIndex(initPart: BasicEchartsPart | undefined) {
 }
 
 const DataIngestionChart: FC = (): JSX.Element => {
-  const chart = useRef<null | ReactEChartsCore>(null);
+  const chart = useRef<ReactEChartsCore>(null);
   const hoverIndex = useRef<null | number>(null);
   useEffect(() => {
     function handleMouse(info: { target: BasicEchartsPart }) {
       hoverIndex.current = getParentSeriesIndex(info.target);
     }
 
-    if (chart.current !== null) {
-      const zr = chart.current.getEchartsInstance().getZr();
-      zr.on("mousemove", handleMouse);
-      return () => zr.off("mousemove", handleMouse);
-    }
-
-    return undefined;
+    const zr = chart.current?.getEchartsInstance().getZr();
+    zr?.on("mousemove", handleMouse);
+    return () => zr?.off("mousemove", handleMouse);
   });
   return (
     <ReactEChartsCore


### PR DESCRIPTION
A couple notes on the additions to `data-ingestion-chart.tsx`:
* On line 251, TypeScript requires that `chart.current` be checked for whether it's null. However, by my understanding, it should never actually be null, since this is happening in a `useEffect` callback which will only be called after the component has rendered and stored a value in `chart` via the `ref` attribute. Is there a better way to handle this than a `null` check?
* On line 37, a minimal type is declared to handle ECharts's graph parts, since the [echarts-for-react](https://github.com/hustcc/echarts-for-react) wrapper doesn't seem to provide types for the more internal aspects of ECharts