### PR TITLE
chore: bump findable ui package (data-explorer-ui) to 0.23.1 (#2736)

### DIFF
--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -8,7 +8,7 @@
       "name": "next",
       "version": "0.1.0",
       "dependencies": {
-        "@clevercanary/data-explorer-ui": "0.23.0",
+        "@clevercanary/data-explorer-ui": "0.23.1",
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
         "@mdx-js/loader": "^2.3.0",
@@ -654,9 +654,9 @@
       "dev": true
     },
     "node_modules/@clevercanary/data-explorer-ui": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.23.0.tgz",
-      "integrity": "sha512-/9Th/trcUcVU8V/+ChQ3vJ39PjiTJlYkSJuAg0vnIwFQKSFoXEbtNMYzC5o98g5A+7fMrCba3JrMPvuRPaEyCw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.23.1.tgz",
+      "integrity": "sha512-+5bdeTitYpBFLn0JfdbA7PydZK9TQeCtTK/qKT7WTsEZ0J4dtBYe+1GcpiKPRYvVzRecRDzzN2tatcCG/E+P2A==",
       "peerDependencies": {
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
@@ -17238,9 +17238,9 @@
       "dev": true
     },
     "@clevercanary/data-explorer-ui": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.23.0.tgz",
-      "integrity": "sha512-/9Th/trcUcVU8V/+ChQ3vJ39PjiTJlYkSJuAg0vnIwFQKSFoXEbtNMYzC5o98g5A+7fMrCba3JrMPvuRPaEyCw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.23.1.tgz",
+      "integrity": "sha512-+5bdeTitYpBFLn0JfdbA7PydZK9TQeCtTK/qKT7WTsEZ0J4dtBYe+1GcpiKPRYvVzRecRDzzN2tatcCG/E+P2A==",
       "requires": {}
     },
     "@corex/deepmerge": {

--- a/next/package.json
+++ b/next/package.json
@@ -10,7 +10,7 @@
     "convert-cser-publications": "cd scripts && node convert-cser-publications.js"
   },
   "dependencies": {
-    "@clevercanary/data-explorer-ui": "0.23.0",
+    "@clevercanary/data-explorer-ui": "0.23.1",
     "@emotion/react": "11.10.4",
     "@emotion/styled": "11.10.4",
     "@mdx-js/loader": "^2.3.0",


### PR DESCRIPTION
Closes #2736 