### PR TITLE
fix: remove unnecessary cser1 links (#2743)

### DIFF
--- a/next/docs/consortia/cser/projects/cser1.mdx
+++ b/next/docs/consortia/cser/projects/cser1.mdx
@@ -4,8 +4,7 @@ import { BreadcrumbsProjects, Link } from "../../../../components";
 
 # Clinical Sequencing Exploratory Research
 
-<p>The precursor to the current CSER consortium was the <Link
-  label="Clinical Sequencing Exploratory Research (CSER1) Consortium" url="https://cser1.cser-consortium.org/" />, a
+<p>The precursor to the current CSER consortium was the Clinical Sequencing Exploratory Research (CSER1) Consortium, a
   national multi-site research program funded jointly by the National Human Genome Research Institute (NHGRI) and
   National Cancer Institute (NCI), which conducted multidimensional, translational research to evaluate the integration
   of genome and exome sequencing into clinical care. Comprising of over 300 clinicians, scientists, ethicists,
@@ -14,6 +13,3 @@ import { BreadcrumbsProjects, Link } from "../../../../components";
   clinical care. Through this expertise and research, CSER1 has and continues to develop and share innovations and best
   practices in areas such as variant classification, return of results, additional (incidental) findings, informed
   consent, and ethical, legal and social implications of sequencing.</p>
-
-<p>Learn more about CSER1 at{" "}
-  <Link label="https://cser1.cser-consortium.org" url="https://cser1.cser-consortium.org" />.</p>

--- a/next/docs/consortia/cser/research-materials.mdx
+++ b/next/docs/consortia/cser/research-materials.mdx
@@ -4,8 +4,7 @@ import { BreadcrumbsCSER, Link, ResearchMaterials } from "../../../components";
 
 # CSER Research Materials
 
-<p>The <Link label="Clinical Sequencing Exploratory Research (CSER Phase 1) consortium"
-             url="https://cser1.cser-consortium.org" />
+<p>The Clinical Sequencing Exploratory Research (CSER Phase 1) consortium
   and Clinical Sequencing Evidence-Generating Research (CSER Phase 2) consortium has produced a vast amount of
   publications and materials from their studies. Below are the research materials that CSER have shared with the
   research community.</p>


### PR DESCRIPTION
I've also removed a link from the *top* of the Projects/CSER1 page, which wasn't mentioned in the ticket