### PR TITLE
Update overview.md to drop dbGaP as an example of a cetralized data w…

### DIFF
--- a/content/overview/overview.md
+++ b/content/overview/overview.md
@@ -8,7 +8,7 @@ description: "AnVIL is NHGRI's Genomic Data Science Analysis, Visualization, and
 
 <hero>AnVIL is NHGRI's Genomic Data Science Analysis, Visualization, and Informatics Lab-Space.</hero>
 
-The traditional model of genomic data sharing – centralized data warehouses such as dbGaP from which researchers
+The traditional model of genomic data sharing – centralized data warehouses from which researchers
 download data to analyze locally – is increasingly unsustainable. Not only are transfer/download costs prohibitive, but
 this approach also leads to redundant siloed compute infrastructure and makes ensuring security and compliance of
 protected data highly problematic.


### PR DESCRIPTION
…arehouse from wich researchers download data.

This change was proposed by NHGRI on 29OCT2023.