### PR TITLE
chore: removed gatsby-plugin-catch-links (#2927)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,7 +22,6 @@ module.exports = {
   },
   plugins: [
     "gatsby-plugin-image",
-    "gatsby-plugin-catch-links",
     {
       resolve: "gatsby-plugin-google-tagmanager",
       options: {


### PR DESCRIPTION
Removed `gatsby-plugin-catch-links`.