### PR TITLE
feat: added anvil 2024 community conference to home page carousel (#3112)

### DIFF
--- a/next/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/next/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -17,6 +17,16 @@ export function buildCarouselCards(portalURL: string): SectionCard[] {
     {
       links: [
         {
+          label: ACTION_LABEL.LEARN_MORE,
+          url: "https://anvilproject.org/events/anvil2024-community-conference",
+        },
+      ],
+      text: "We are thrilled to announce the inaugural AnVIL Community Conference, taking place on November 12-13, 2024, in Cold Spring Harbor, NY.",
+      title: "AnVIL Community Conference 2024",
+    },
+    {
+      links: [
+        {
           label: ACTION_LABEL.PAPER,
           url: "https://www.science.org/doi/10.1126/science.abl3533",
         },


### PR DESCRIPTION
Closes #3112.

<img width="2559" alt="image" src="https://github.com/user-attachments/assets/fdafde6f-75fc-4ed0-a5ca-18ae85d2d722">
