### PR TITLE
chore: added deprecation warning to free gtex export article (#3259)

### DIFF
--- a/docs/news/2020/11/20/nhgri-anvil-now-supports-free-export-of-gtex-data.mdx
+++ b/docs/news/2020/11/20/nhgri-anvil-now-supports-free-export-of-gtex-data.mdx
@@ -7,6 +7,10 @@ title: "NHGRI AnVIL Cloud Platform Now Supports Free Export of GTEx Data"
 
 <NewsHero {...frontmatter} />
 
+<Alert severity="warning">
+  Starting October 1, 2024, the AnVIL Gen3 Commons and free downloadable version of GTEx v8 through Gen3 will be decommissioned. Please see [Sunsetting Gen3 Functionality in AnVIL](/news/2024/09/16/sunsetting-gen3-in-anvil) for more information.
+</Alert>
+
 One of the most widely-used resources for studying the relationship between genetic variation and gene expression is the [Genotype-Tissue Expression (GTEx) project][1]. Established by the NIH Common Fund in 2010, the recent [GTEx V8 dataset][2] represents the largest atlas of human gene expression and corresponding trait loci to date (dbGaP accession: [phs000424.v8.p2][3]).
 
 This dataset contains genotype data from 838 postmortem donors and 17,382 RNA-seq samples across 54 tissue sites and 2 cell lines. The [GTEx Portal][4] provides uniformly processed gene expression data, a QTL Browser, and a mechanism by which to request available biospecimens to allow researchers to study the impact of genetic variation on complex traits and diseases.

--- a/site-config/anvil-portal/dev/navigation/overview.ts
+++ b/site-config/anvil-portal/dev/navigation/overview.ts
@@ -32,7 +32,7 @@ export const OVERVIEW: NavigationEntry = {
           selectedMatch: SELECTED_MATCH.EQUALS,
           url: ROUTES.OVERVIEW,
         },
-                {
+        {
           label: "NIH Data Management and Sharing Policy Requirements",
           url: `${ROUTES.OVERVIEW}/${PATH_SEGMENTS.DMS_REQUIRMENTS}`,
         },


### PR DESCRIPTION
- Added a deprecation warning to https://anvilproject.org/news/2020/11/20/nhgri-anvil-now-supports-free-export-of-gtex-data
- Fixed a formatting error from an unrelated commit