### PR TITLE
fix: removed gen3 references from team.mdx (#3292 #3061)

### DIFF
--- a/docs/team.mdx
+++ b/docs/team.mdx
@@ -1,5 +1,5 @@
 ---
-description: "AnVIL is a collaboration between the Broad, JHU, UChicago, RPCI, UCSC, Penn State, WUSTL, OHSU, Harvard Medical School, Vanderbilt & CUNY."
+description: "AnVIL is a collaboration between the Broad, JHU, RPCI, UCSC, Penn State, WUSTL, OHSU, Harvard Medical School, Vanderbilt & CUNY."
 title: "Team"
 ---
 
@@ -7,13 +7,12 @@ title: "Team"
 
 <Alert icon={false} severity="info">
   AnVIL is a collaborative project between the Broad Institute, Johns Hopkins
-  University, the University of Chicago, Roswell Park Cancer Institute,
-  University of California at Santa Cruz, Penn State University, Washington
-  University, Oregon Health and Sciences University, Harvard Medical School,
-  Vanderbilt University, and City University of New York.
+  University, Roswell Park Cancer Institute, University of California at Santa Cruz,
+  Penn State University, Washington University, Oregon Health and Sciences University,
+  Harvard Medical School, Vanderbilt University, and City University of New York.
 </Alert>
 
-Members of these teams are also involved with platform and software development representing the Terra, Galaxy, Bioconductor, Gen3, and Dockstore teams.
+Members of these teams are also involved with platform and software development representing the Terra, Galaxy, Bioconductor, and Dockstore teams.
 
 ## American Heart Association
 
@@ -78,10 +77,6 @@ Members of these teams are also involved with platform and software development 
 ## University of California, Santa Cruz
 
 - [Benedict Paten](https://cglgenomics.ucsc.edu/team/)
-
-## University of Chicago
-
-- [Robert Grossman](https://rgrossman.com/)
 
 ## Vanderbilt University Medical Center
 


### PR DESCRIPTION
Updated teams.mdx as follows:

- Remove "Gen3," from  "Members of these teams are also involved with platform and software development representing the Terra, Galaxy, Bioconductor, **Gen3,** and Dockstore teams."
- Remove references to Gen3 contributors from the University of Chicago as instructed by @NoopDog 