### PR TITLE
fix: removed email from resources-for-anvil-users.mdx (#3286)

### DIFF
--- a/docs/faq/resources-for-anvil-users.mdx
+++ b/docs/faq/resources-for-anvil-users.mdx
@@ -40,5 +40,5 @@ with GCP.
 
 ## Who can I contact with further questions?
 
-**_AnVIL Team_**: [help@lists.anvilproject.org]({anvilHelp})\
+**_AnVIL Team_**: [View our Help Page](https://anvilproject.org/help)\
 **_NHGRI AnVIL Contact_**: [anvil@mail.nih.gov](mailto:anvil@mail.nih.gov)


### PR DESCRIPTION
- Replaced the link to email [help@lists.anvilproject.org](mailto:help@lists.anvilproject.org) with a link to https://anvilproject.org/help