### PR TITLE
fix: changed help link to an internal link (#3302)

### DIFF
--- a/docs/faq/resources-for-anvil-users.mdx
+++ b/docs/faq/resources-for-anvil-users.mdx
@@ -40,5 +40,5 @@ with GCP.
 
 ## Who can I contact with further questions?
 
-**_AnVIL Team_**: [View our Help Page](https://anvilproject.org/help)\
+**_AnVIL Team_**: [View our Help Page](/help)\
 **_NHGRI AnVIL Contact_**: [anvil@mail.nih.gov](mailto:anvil@mail.nih.gov)


### PR DESCRIPTION
- Change link to help page from an external to internal link so it opens in the same tab