### PR TITLE
feat: replaced reference to gen3 on data-access-controls (#3309 #3061)

### DIFF
--- a/docs/learn/accessing-data/data-access-controls.mdx
+++ b/docs/learn/accessing-data/data-access-controls.mdx
@@ -30,4 +30,4 @@ To synchronize dbGaP approvals with Terra, dbGaP periodically deposits a copy of
 
 ## Data Access Monitoring and Logging
 
-Both Terra and Gen3 operate in a FISMA-Moderate environment and comply with all requirements set forth in NIST-800-53. This includes robust logging of access to data, periodic audits, and monitoring for abnormal use patterns.
+Both Terra and the AnVIL Data Explorer operate in a FISMA-Moderate environment and comply with all requirements set forth in NIST-800-53. This includes robust logging of access to data, periodic audits, and monitoring for abnormal use patterns.


### PR DESCRIPTION
Replaced a reference to Gen3 on [data-access-controls.mdx](https://anvilproject.org/learn/accessing-data/data-access-controls) with a reference to the AnVIL Data Explorer as specified in #3061 
