### PR TITLE
content: removed references to gen3 on overview-of-account-setup (#3311 #3061)

### DIFF
--- a/docs/learn/account-setup/overview-of-account-setup.mdx
+++ b/docs/learn/account-setup/overview-of-account-setup.mdx
@@ -5,11 +5,11 @@ title: "Account Setup"
 
 # Overview of Account Setup
 
-To use AnVIL, you will need a Google account for authenticating with Terra and Gen3 and to associate your Terra account with a Google Cloud Platform (GCP) account.
+To use AnVIL, you will need a Google account for authenticating with Terra and the AnVil Data Explorer and to associate your Terra account with a Google Cloud Platform (GCP) account.
 
 If you will be accessing controlled-access data, you will also need an eRA commons id or to be a member of a data sharing consortium.
 
-To enable dbGaP data use authorizations to flow through from dbGaP to Terra, you will need to link your Terra account with your eRA commons ID and your Gen3 account.
+To enable dbGaP data use authorizations to flow through from dbGaP to Terra, you will need to link your Terra account with your eRA commons ID.
 
 The guides below walk you through each step in the account setup process.
 
@@ -19,10 +19,6 @@ The guides below walk you through each step in the account setup process.
 
 1. [Set up Terra account with non-Google email](https://support.terra.bio/hc/en-us/articles/360029186611-Setting-up-a-Google-account-with-a-non-Google-email) - If your email is not associated with a Google identity, follow these steps to create a Google account that is associated with your non-Gmail, institutional email address.
 
-1. [Set up a Gen3 account](https://gen3.theanvil.io/login) Create a Gen3 account by logging in with your NIH, Google, or RAS login credentials. This allows you to use the Gen3 data explorer to create artificial cohorts over AnVIL datasets that have been indexed by Gen3.
-
-1. [Link your Gen3 and Terra accounts](https://support.terra.bio/hc/en-us/articles/360050390451) - Follow these step-by-step instructions to link your Gen3 credentials to your Terra account. This allows you to analyze Gen3 data on Terra.
-
 1. [Link your Terra and eRA Commons ID](https://support.terra.bio/hc/en-us/articles/360038086332-Linking-Terra-to-External-Servers) - To use controlled-access data on Terra, you will need to link your Terra user ID to your authorization account (such as a dbGaP account). Linking to external servers will allow Terra to automatically determine if you can access controlled datasets hosted in Terra (ex. TCGA, TOPMed, etc.) based on your approved dbGaP applications.
 
-Next, see [Requesting Data Access](/learn/accessing-data/requesting-data-access) for more information about obtaining access to controlled access data and configuring Terra and Gen3 to read your data access privileges from dbGaP or your consortia access control list.
+Next, see [Requesting Data Access](/learn/accessing-data/requesting-data-access) for more information about obtaining access to controlled access data and configuring Terra to read your data access privileges from dbGaP or your consortia access control list.

--- a/docs/learn/account-setup/overview-of-account-setup.mdx
+++ b/docs/learn/account-setup/overview-of-account-setup.mdx
@@ -5,11 +5,11 @@ title: "Account Setup"
 
 # Overview of Account Setup
 
-To use AnVIL, you will need a Google account for authenticating with Terra and the AnVil Data Explorer and to associate your Terra account with a Google Cloud Platform (GCP) account.
+To use AnVIL, you will need a Google account to authenticate with Terra and the AnVil Data Explorer and to associate your Terra account with a Google Cloud Platform (GCP) account.
 
-If you will be accessing controlled-access data, you will also need an eRA commons id or to be a member of a data sharing consortium.
+If you are accessing controlled-access data, you will also need an eRA commons id or to be a member of a data-sharing consortium.
 
-To enable dbGaP data use authorizations to flow through from dbGaP to Terra, you will need to link your Terra account with your eRA commons ID.
+To enable dbGaP data use authorizations to flow through from dbGaP to Terra, you must link your Terra account with your eRA Commons ID.
 
 The guides below walk you through each step in the account setup process.
 
@@ -19,6 +19,6 @@ The guides below walk you through each step in the account setup process.
 
 1. [Set up Terra account with non-Google email](https://support.terra.bio/hc/en-us/articles/360029186611-Setting-up-a-Google-account-with-a-non-Google-email) - If your email is not associated with a Google identity, follow these steps to create a Google account that is associated with your non-Gmail, institutional email address.
 
-1. [Link your Terra and eRA Commons ID](https://support.terra.bio/hc/en-us/articles/360038086332-Linking-Terra-to-External-Servers) - To use controlled-access data on Terra, you will need to link your Terra user ID to your authorization account (such as a dbGaP account). Linking to external servers will allow Terra to automatically determine if you can access controlled datasets hosted in Terra (ex. TCGA, TOPMed, etc.) based on your approved dbGaP applications.
+1. [Link your Terra and eRA Commons ID](https://support.terra.bio/hc/en-us/articles/360038086332-Linking-Terra-to-External-Servers) - To use controlled-access data on Terra, you will need to link your Terra user ID to your authorization account (such as a dbGaP account). Linking to external servers will allow Terra to automatically determine if you can access controlled datasets hosted in Terra (ex., TCGA, TOPMed, etc.) based on your approved dbGaP applications.
 
-Next, see [Requesting Data Access](/learn/accessing-data/requesting-data-access) for more information about obtaining access to controlled access data and configuring Terra to read your data access privileges from dbGaP or your consortia access control list.
+Next, see [Requesting Data Access](/learn/accessing-data/requesting-data-access) for more information about accessing controlled access data and configuring Terra to read your data access privileges from dbGaP or your consortia access control list.


### PR DESCRIPTION
Replaced and removed references to Gen3 on `overview-of-account-setup.mdx` as specified in #3061 