### PR TITLE
content: replaced references to gen3 on security.mdx (#3313 #3061)

### DIFF
--- a/docs/overview/security.mdx
+++ b/docs/overview/security.mdx
@@ -18,11 +18,11 @@ AnVIL systems also follow a model of continual assessment. This means the code i
 
 ## Platform Services
 
-The AnVIL is made up of a variety of software developed by different institutions including the Broad Institute’s Terra platform, the University of Chicago Center for Translational Data Science’s Gen3 platform, and the University of California Santa Cruz’s Dockstore software. These are collectively referred to as "Platform Services."
+The AnVIL is made up of a variety of software developed by different institutions including the Broad Institute’s Terra platform and the University of California Santa Cruz’s AnVIL Data Explorer platform and Dockstore software. These are collectively referred to as "Platform Services."
 
 ## Third Party Applications
 
-In addition to Platform Services, third parties may write their own tools using the APIs from Terra, Gen3, or Dockstore. These tools are referred to as "3rd party applications" and may have their own authentication and authorization abilities. They exist outside the security boundaries of the Platform Services.
+In addition to Platform Services, third parties may write their own tools using the APIs from Terra, the AnVIL Data Explorer, or Dockstore. These tools are referred to as "3rd party applications" and may have their own authentication and authorization abilities. They exist outside the security boundaries of the Platform Services.
 
 ## Authority to Operate
 


### PR DESCRIPTION
Replaced references to gen3 on security.mdx as specified in #3061 