### PR TITLE
fix: Update anvil2024-community-conference to update name of scientific lead for deep learning models CoFest

### DIFF
--- a/docs/events/anvil2024-community-conference.mdx
+++ b/docs/events/anvil2024-community-conference.mdx
@@ -74,7 +74,7 @@ AnVIL collaborative events are emphatically called CollaborationFests! rather th
 “Hackathon” implies an emphasis on code. CoFests! are about contributing and learning how to contribute to all aspects of AnVIL, including training material, community infrastructure, documentation, unit tests, bug reports, and yes, even code. First and foremost AnVIL CoFests! are about growing the community of future contributors.
 
 This year's CoFests! topics are listed below: 
-- Deploying, Training, and Interpreting Deep Learning Models for regulatory genomics in AnVIL (Led by: Anshul Kundaje & Vivek Ramalingam, Stanford University)
+- Deploying, Training, and Interpreting Deep Learning Models for regulatory genomics in AnVIL (Led by: Anshul Kundaje & Vivekanandan Ramalingam, Stanford University)
 - Polygenic Risk Score (PRS) Analysis in AnVIL (Led by: Matthew Lebo, Harvard Medical School)
 - How to Run Your Tool in AnVIL with WDL (Led by: Allie Cliffe, Broad Institute of MIT and Harvard)
 - Brainstorming Feature Requests for AnVIL (Led by: Ava Hoffman, Fred Hutch Cancer Center / AnVIL Outreach)


### PR DESCRIPTION
Replace name of scientific lead per lead's request