### PR TITLE
content: add link to instructions for downloading GTEx data to AnVIL using DUOS

### DIFF
--- a/docs/learn/reference/gtex-v8-free-egress-instructions.mdx
+++ b/docs/learn/reference/gtex-v8-free-egress-instructions.mdx
@@ -9,3 +9,6 @@ title: "GTEx v8 - Egress Instructions"
 <Alert severity="warning">
   Starting October 1, 2024, the AnVIL Gen3 Commons and free downloadable version of GTEx v8 through Gen3 will be decommissioned. Please see [Sunsetting Gen3 Functionality in AnVIL](/news/2024/09/16/sunsetting-gen3-in-anvil) for more information.
 </Alert>
+
+## Download GTEx data to AnVIL using DUOS
+For step-by-step instructions to access and export GTEx data to an AnVIL workspace via DUOS, see [How to access GTEx data in Terra](https://support.terra.bio/hc/en-us/articles/30873545719451-How-to-access-GTEx-data-in-Terra). 


### PR DESCRIPTION
Added a link to step-by-step instructions from Terra Support docs to access and export GTEx data to an AnVIL (Terra) workspace using DUOS.