### PR TITLE
content: update sunsetting-gen3-in-anvil with link to data access via DUOS

### DIFF
--- a/docs/news/2024/09/16/sunsetting-gen3-in-anvil.mdx
+++ b/docs/news/2024/09/16/sunsetting-gen3-in-anvil.mdx
@@ -9,7 +9,9 @@ title: "Sunsetting Gen3 Functionality in AnVIL"
 
 Dear AnVIL Users,
 
-We want to make you aware that starting **October 1, 2024**, the AnVIL Gen3 Commons and free downloadable version of GTEx v8 through Gen3 will be decommissioned. The [AnVIL Data Explorer]({browserURL}/beta-announcement), which has been beta launched and now hosts over 250 AnVIL datasets, will be the recommended method for accessing GTEx data through AnVIL.
+We want to make you aware that starting **October 1, 2024**, the AnVIL Gen3 Commons and free downloadable version of GTEx v8 through Gen3 will be decommissioned. The [AnVIL Data Explorer]({browserURL}/beta-announcement), which has been beta launched and now hosts over 250 AnVIL datasets, will be the recommended method for accessing GTEx data through AnVIL.      
+
+**AnVIL users working in anvil.terra.bio can also access and export GTEx data via DUOS**. See step-by-step instructions [here](https://support.terra.bio/hc/en-us/articles/30873545719451-How-to-access-GTEx-data-in-Terra). 
 
 More details about the anticipated scope of impact are described below.
 


### PR DESCRIPTION
Added a link to a Terra Support article with step-by-step instructions for accessing and exporting GTEx data to a Terra workspace using DUOS. Note that until the export functionality in the Data Explorer is working, this is the preferred way for users to access GTEx data.