### PR TITLE
feat: replace catalog with early access studies link in header (#3564)

### DIFF
--- a/components/Home/components/Section/components/SectionDatasets/common/utils.ts
+++ b/components/Home/components/Section/components/SectionDatasets/common/utils.ts
@@ -1,136 +1,64 @@
-import { SectionCardWithLink } from "../../../../../common/entities";
+import { SectionCard } from "../../../../../common/entities";
 
-const ACTION_LABEL = {
-  UNSPECIFIED: "",
-};
-const CONSORTIA_ROUTE = "data/consortia";
-
-/**
- * Returns the dataset cards for the datasets section.
- * @param portalURL - Portal URL.
- * @returns dataset cards.
- */
-export function buildDatasetCards(portalURL: string): SectionCardWithLink[] {
-  return [
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/ALS-Compute`,
-      },
-      text: "",
-      title: "ALS-Compute",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/CARD`,
-      },
-      text: "",
-      title: "CARD",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/CCDG`,
-      },
-      text: "Centers for Common Disease Genomics",
-      title: "CCDG",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/CMG`,
-      },
-      text: "Centers for Mendelian Genetics",
-      title: "CMG",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/CMH`,
-      },
-      text: "",
-      title: "CMH",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/Convergent%20Neuroscience`,
-      },
-      text: "Convergent Neuro Consortium",
-      title: "Convergent Neuroscience",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/CSER`,
-      },
-      text: "Clinical Sequencing Evidence-Generating Research Consortium",
-      title: "CSER",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/eMERGE`,
-      },
-      text: "Electronic and MEdical Records and Genomics Project",
-      title: "eMERGE",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/GREGoR`,
-      },
-      text: "",
-      title: "GREGoR",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/GTEx`,
-      },
-      text: "The Genotype-Tissue Expression Project",
-      title: "GTEx",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/HPRC`,
-      },
-      text: "Human Pangenome Reference Consortium",
-      title: "HPRC",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/PAGE`,
-      },
-      text: "Population Architecture Using Genomics and Epidemiology",
-      title: "PAGE",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/T2T`,
-      },
-      text: "Telomere-to-Telomere",
-      title: "T2T",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/WGSPD1`,
-      },
-      text: "",
-      title: "WGSPD1",
-    },
-    {
-      link: {
-        label: ACTION_LABEL.UNSPECIFIED,
-        url: `${portalURL}/${CONSORTIA_ROUTE}/1000G`,
-      },
-      text: "The 1000 Genomes Project",
-      title: "1000G",
-    },
-  ];
-}
+export const CARDS: Omit<SectionCard, "links">[] = [
+  {
+    text: "",
+    title: "ALS-Compute",
+  },
+  {
+    text: "",
+    title: "CARD",
+  },
+  {
+    text: "Centers for Common Disease Genomics",
+    title: "CCDG",
+  },
+  {
+    text: "Centers for Mendelian Genetics",
+    title: "CMG",
+  },
+  {
+    text: "",
+    title: "CMH",
+  },
+  {
+    text: "Convergent Neuro Consortium",
+    title: "Convergent Neuroscience",
+  },
+  {
+    text: "Clinical Sequencing Evidence-Generating Research Consortium",
+    title: "CSER",
+  },
+  {
+    text: "Electronic and MEdical Records and Genomics Project",
+    title: "eMERGE",
+  },
+  {
+    text: "",
+    title: "GREGoR",
+  },
+  {
+    text: "The Genotype-Tissue Expression Project",
+    title: "GTEx",
+  },
+  {
+    text: "Human Pangenome Reference Consortium",
+    title: "HPRC",
+  },
+  {
+    text: "Population Architecture Using Genomics and Epidemiology",
+    title: "PAGE",
+  },
+  {
+    text: "Telomere-to-Telomere",
+    title: "T2T",
+  },
+  {
+    text: "",
+    title: "WGSPD1",
+  },
+  {
+    text: "The 1000 Genomes Project",
+    title: "1000G",
+  },
+];

--- a/components/Home/components/Section/components/SectionDatasets/components/Datasets/components/Cards/cards.styles.ts
+++ b/components/Home/components/Section/components/SectionDatasets/components/Datasets/components/Cards/cards.styles.ts
@@ -5,18 +5,14 @@ import {
 import styled from "@emotion/styled";
 import { Card as MCard } from "@mui/material";
 import {
-  GridCardContent as DefaultContent,
   CardSection as DefaultSection,
   GridCard,
+  GridCardContent as DefaultContent,
 } from "../../../../../../../Card/card.styles";
 
 export const Card = styled(GridCard)`
   align-items: stretch; /* card action area consumes height of card */
   min-height: 74px;
-
-  .MuiCardActionArea-root {
-    text-decoration: none;
-  }
 
   ${mediaTabletUp} {
     grid-column: auto / span 6;
@@ -24,9 +20,9 @@ export const Card = styled(GridCard)`
 ` as typeof MCard;
 
 export const CardSection = styled(DefaultSection)`
+  align-items: center;
   gap: 0;
-  grid-template-columns: 1fr auto;
-  height: 100%; /* parent (card action area) is block element */
+  grid-template-columns: 1fr;
 
   ${mediaDesktopSmallUp} {
     gap: 16px;

--- a/components/Home/components/Section/components/SectionDatasets/components/Datasets/components/Cards/cards.tsx
+++ b/components/Home/components/Section/components/SectionDatasets/components/Datasets/components/Cards/cards.tsx
@@ -1,37 +1,25 @@
 import { CardSecondaryText } from "@databiosphere/findable-ui/lib/components/common/Card/components/CardSecondaryText/cardSecondaryText";
 import { CardTitle } from "@databiosphere/findable-ui/lib/components/common/Card/components/CardTitle/cardTitle";
-import { ForwardArrowIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ForwardArrowIcon/forwardArrowIcon";
 import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
-import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
-import { CardActionArea as MCardActionArea } from "@mui/material";
 import { Fragment } from "react";
-import { SectionCardWithLink } from "../../../../../../../../common/entities";
-import { CardCTA } from "../../../../../../../Card/card.styles";
+import { SectionCard } from "../../../../../../../../common/entities";
 import { Card, CardContent, CardSection } from "./cards.styles";
 
 interface CardsProps {
-  cards: SectionCardWithLink[];
+  cards: Omit<SectionCard, "links">[];
 }
 
 export const Cards = ({ cards }: CardsProps): JSX.Element => {
   return (
     <Fragment>
-      {cards.map(({ link, text, title }, i) => (
+      {cards.map(({ text, title }, i) => (
         <Card key={i} component={RoundedPaper}>
-          <MCardActionArea
-            href={link.url}
-            target={link.target || ANCHOR_TARGET.SELF}
-          >
-            <CardSection>
-              <CardContent>
-                <CardTitle>{title}</CardTitle>
-                {text && <CardSecondaryText>{text}</CardSecondaryText>}
-              </CardContent>
-              <CardCTA>
-                <ForwardArrowIcon color="primary" fontSize="small" />
-              </CardCTA>
-            </CardSection>
-          </MCardActionArea>
+          <CardSection>
+            <CardContent>
+              <CardTitle>{title}</CardTitle>
+              {text && <CardSecondaryText>{text}</CardSecondaryText>}
+            </CardContent>
+          </CardSection>
         </Card>
       ))}
     </Fragment>

--- a/components/Home/components/Section/components/SectionDatasets/sectionDatasets.styles.ts
+++ b/components/Home/components/Section/components/SectionDatasets/sectionDatasets.styles.ts
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
 import { mediaTabletLargeUp } from "../../../../../../styles/common/mixins/breakpoints";
 import {
-  SectionActions as DefaultActions,
+  sectionGrid,
   SectionHeadline as DefaultHeadline,
   SectionTitle as DefaultTitle,
-  sectionGrid,
 } from "../../section.styles";
+import { mediaTabletUp } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
 
 export const Headline = styled(DefaultHeadline)`
   gap: 24px;
@@ -24,6 +24,24 @@ export const SectionTitle = styled(DefaultTitle)`
   }
 `;
 
-export const SectionActions = styled(DefaultActions)`
-  justify-content: center;
+export const SectionActions = styled.div`
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 1fr;
+
+  ${mediaTabletUp} {
+    grid-template-columns: repeat(12, 1fr);
+
+    .MuiButton-root {
+      &:first-of-type {
+        grid-column: 1 / 7;
+        justify-self: flex-end;
+      }
+
+      &:last-of-type {
+        grid-column: 7 / 12;
+        justify-self: flex-start;
+      }
+    }
+  }
 `;

--- a/components/Home/components/Section/components/SectionDatasets/sectionDatasets.tsx
+++ b/components/Home/components/Section/components/SectionDatasets/sectionDatasets.tsx
@@ -1,6 +1,4 @@
-import { ButtonSecondary } from "@databiosphere/findable-ui/lib/components/common/Button/components/ButtonSecondary/buttonSecondary";
-import { REL_ATTRIBUTE } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
-import NLink from "next/link";
+import Link from "next/link";
 import { Section, SectionLayout } from "../../section.styles";
 import { Datasets } from "./components/Datasets/datasets";
 import { Metrics } from "./components/Metrics/metrics";
@@ -9,18 +7,16 @@ import {
   SectionActions,
   SectionTitle,
 } from "./sectionDatasets.styles";
+import { Button } from "@mui/material";
+import {
+  COLOR,
+  VARIANT,
+} from "@databiosphere/findable-ui/lib/styles/common/mui/button";
 
 const CONSORTIA_ROADMAP = "/consortia";
 const CONTRIBUTE_DATA = "/learn/submit-data";
-const EXPLORE_DATASETS = "/data/consortia";
 
-interface SectionDatasetsProps {
-  portalURL: string;
-}
-
-export const SectionDatasets = ({
-  portalURL,
-}: SectionDatasetsProps): JSX.Element => {
+export const SectionDatasets = (): JSX.Element => {
   return (
     <Section>
       <SectionLayout>
@@ -32,18 +28,22 @@ export const SectionDatasets = ({
         </Headline>
         <Datasets />
         <SectionActions>
-          <NLink href={CONSORTIA_ROADMAP} legacyBehavior passHref>
-            <ButtonSecondary href="passHref">Consortia Roadmap</ButtonSecondary>
-          </NLink>
-          <ButtonSecondary
-            href={`${portalURL}${EXPLORE_DATASETS}`}
-            rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+          <Button
+            color={COLOR.SECONDARY}
+            component={Link}
+            href={CONSORTIA_ROADMAP}
+            variant={VARIANT.CONTAINED}
           >
-            Explore Datasets
-          </ButtonSecondary>
-          <ButtonSecondary href={CONTRIBUTE_DATA}>
+            Consortia Roadmap
+          </Button>
+          <Button
+            color={COLOR.SECONDARY}
+            component={Link}
+            href={CONTRIBUTE_DATA}
+            variant={VARIANT.CONTAINED}
+          >
             Contribute Data
-          </ButtonSecondary>
+          </Button>
         </SectionActions>
       </SectionLayout>
     </Section>

--- a/docs/consortia.mdx
+++ b/docs/consortia.mdx
@@ -2,8 +2,8 @@
 title: "Data Consortia"
 ---
 
+
 import { Card, Consortia } from "../components";
-import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import DataIngestionChart from "../components/Consortia/CSER/components/DataIngestionChart/dataIngestionChart";
 
 # Data Consortia
@@ -21,11 +21,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
         label: "Learn More",
         url: "https://card.nih.gov/",
       },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/CARD",
-      },
     ]}
     text="CARD is a collaborative initiative of the National Institute on Aging (NIA) and the National Institute of Neurological Disorders and Stroke (NINDS) that supports basic, translational, and clinical research on Alzheimer’s disease and related dementias. CARD’s central mission is to initiate, stimulate, accelerate, and support research that will lead to the development of improved treatments and preventions for these diseases. Through CARD, researchers work across scientific domains and disease boundaries to bridge basic, preclinical, and clinical research with the goal of accelerating translational research on these devastating diseases."
     title="CARD"
@@ -35,11 +30,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
       {
         label: "Learn More",
         url: "https://www.genome.gov/Funded-Programs-Projects/NHGRI-Genome-Sequencing-Program/Centers-for-Common-Disease-Genomics",
-      },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/CCDG",
       },
     ]}
     text="The Centers for Common Disease Genomics are a collaborative large-scale genome sequencing effort to comprehensively identify rare risk and protective variants contributing to multiple common disease phenotypes."
@@ -51,11 +41,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
         label: "Learn More",
         url: "https://www.genome.gov/Funded-Programs-Projects/NHGRI-Genome-Sequencing-Program/Centers-for-Mendelian-Genomics-CMG",
       },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/CMG",
-      },
     ]}
     text="The Centers for Mendelian Genomics is a multi-center collaboration aimed at identifying the genes responsible for Mendelian phenotypes by whole exome and whole genome sequencing."
     title="CMG"
@@ -66,11 +51,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
         label: "Learn More",
         url: "https://gregorconsortium.org/data",
       },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/GREGoR",
-      },
     ]}
     text={
       <span>
@@ -78,7 +58,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
         <ul>
           <li>Learn more about the <Link label="GREGoR Dataset and GREGoR consortium" url="https://gregorconsortium.org/data"/></li>
           <li>Learn how to <Link label="Access GREGoR Data" url="https://gregorconsortium.org/data#accessing-gregor-data"/></li>
-          <li>View the GREGoR Consortium's <Link label="studies and workspaces" url="https://anvilproject.org/data/consortia/GREGoR/studies"/></li>
         </ul>
       </span>
   }
@@ -90,11 +69,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
         label: "Learn More",
         url: "https://gtexportal.org/home/",
       },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/GTEx",
-      },
     ]}
     text="The Genotype-Tissue Expression (GTEx) project is an ongoing effort to build a comprehensive public resource to study tissue-specific gene expression and regulation. Samples were collected from 54 non-diseased tissue sites across nearly 1000 individuals, primarily for molecular assays including WGS, WES, and RNA-Seq."
     title="GTEx"
@@ -105,11 +79,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
         label: "Learn More",
         url: "https://www.internationalgenome.org/",
       },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/1000G",
-      },
     ]}
     text="The 1000 Genomes Project, launched in January 2008, is an international research effort to establish variation profiles across the human population. This open access data set continues to be a valuable resource to geneticists."
     title="1000 G"
@@ -119,11 +88,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
       {
         label: "Learn More",
         url: "/consortia/cser",
-      },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/CSER",
       },
     ]}
     secondaryText="Active 2011 to 2023"
@@ -136,11 +100,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
         label: "Learn More",
         url: "https://emerge-network.org/",
       },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/eMERGE",
-      },
     ]}
     text="The Electronic and MEdical Records and Genomics project (eMERGE) is a national network organized and funded by the NHGRI that combines DNA biorepositories with electronic medical record (EMR) systems for large scale, high-throughput genetic research in support of implementing genomic medicine."
     title="eMERGE"
@@ -150,11 +109,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
       {
         label: "Learn More",
         url: "https://www.genome.gov/Funded-Programs-Projects/Population-Architecture-Using-Genomics-and-Epidemiology",
-      },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/PAGE",
       },
     ]}
     text="The Population Architecture Using Genomics and Epidemiology Consortium investigates ancestrally diverse populations to gain a better understanding of how genetic factors influence susceptibility to disease."
@@ -166,11 +120,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
         label: "Learn More",
         url: "https://humanpangenome.org/",
       },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/HPRC",
-      },
     ]}
     text="The Human Pangenome Reference Consortium aims to modernize the human reference to include a collection of diverse and highly accurate, haplotype-phased genome assemblies. This initiative will generate new technical standards in genome sequencing, scalable and reproducible assembly methods, and pangenomic tool development to ensure comprehensive variant discovery."
     title="HPRC"
@@ -180,11 +129,6 @@ AnVIL hosts data from the following programs and also allows users to submit the
       {
         label: "Learn More",
         url: "https://sites.google.com/ucsc.edu/t2tworkinggroup/home",
-      },
-      {
-        label: "View in Catalog",
-        target: ANCHOR_TARGET.SELF,
-        url: "https://anvilproject.org/data/consortia/T2T/workspaces",
       },
     ]}
     text={

--- a/docs/consortia/cser.mdx
+++ b/docs/consortia/cser.mdx
@@ -2,6 +2,8 @@
 title: "Clinical Sequencing Evidence-Generating Research"
 ---
 
+
+
 import { BreadcrumbsCSER, Figure } from "../../components";
 
 <BreadcrumbsCSER lastCrumb="About" />
@@ -17,10 +19,6 @@ import { BreadcrumbsCSER, Figure } from "../../components";
 The Clinical Sequencing Evidence-Generating Research (CSER) consortium is a national multi-site research program funded by the National Human Genome Research Institute (NHGRI), the National Cancer Institute (NCI) and the National Institute on Minority Health and Health Disparities (NIMHD).
 
 Prioritizing engagement of traditionally underrepresented populations in genomics research, CSER’s seven clinical sites seek to study the effectiveness of integrating genome sequencing into the clinical care of diverse and medically underserved individuals. CSER’s research goals include measuring sequencing’s clinical utility through patient and familial responses to genomic testing and evaluating patient-provider-laboratory interactions that influence the use of sequencing. Drawing from the expertise of clinicians, scientists, ethicists, bioinformaticians, economists, and legal scholars, CSER is poised to develop and share best practices in areas such as the discovery and interpretation of genomic variants, return of results, healthcare utilization, health outcomes and metrics, and the ethical, legal, and social implications of sequencing in diverse populations.
-
-## CSER Workspaces
-
-Please see the [AnVIL Dataset Catalog]({portalURL}/data/consortia/CSER/workspaces) for the list of CSER Workspaces on AnVIL.
 
 ## CSER diversity & inclusion statement
 

--- a/docs/faq/resources-for-anvil-users.mdx
+++ b/docs/faq/resources-for-anvil-users.mdx
@@ -16,7 +16,7 @@ The current list of large-scale datasets which will be available through AnVIL a
 - CSER (coming soon)
 
 The AnVIL Data Dashboard provides a real time view of which data sets and individual projects are available
-on [AnVIL]({portalURL}/data/consortia).
+on [AnVIL Data Explorer]({browserURL}).
 
 ## What user training will AnVIL provide?
 

--- a/docs/faq/using-anvil.mdx
+++ b/docs/faq/using-anvil.mdx
@@ -29,7 +29,7 @@ and later accessible from Gen3.
 
 ## Which of the NHGRI consortium data are available on AnVIL?
 
-Initial releases and project IDs of datasets from the CCDG, CMG, eMERGE, CSER, and GTEx can be found on the [AnVIL Data Dashboard]({portalURL}/data/consortia).
+Initial releases and project IDs of datasets from the CCDG, CMG, eMERGE, CSER, and GTEx can be found on the [AnVIL Data Explorer]({browserURL}).
 
 ## Where can I find documentation to “get started” on AnVIL?
 

--- a/docs/learn/find-data.mdx
+++ b/docs/learn/find-data.mdx
@@ -7,8 +7,8 @@ overview:
     links:
       - label: "AnVIL Data Explorer"
         url: https://explore.anvilproject.org/datasets
-      - label: "AnVIL Dataset Catalog"
-        url: https://anvilproject.org/data
+      - label: "Early Access Studies"
+        url: https://duos.broadinstitute.org
   - label: "Access Data"
     links:
       - /learn/find-data/requesting-data-access

--- a/docs/learn/find-data/requesting-data-access.mdx
+++ b/docs/learn/find-data/requesting-data-access.mdx
@@ -47,7 +47,7 @@ that is housed within the AnVIL.
 ### Submitting A dbGaP Data Access Request
 
 1. **Identify the phsID of the cohort you wish to access.** A helpful list of datasets can be found on
-   our [datasets]({portalURL}/data/consortia) page.
+   our [datasets]({browserURL}/datasets) page.
 1. **Request Access.** Navigate to the dbGaP page for that study and click "Request Access" near the top of the screen.
 1. **Navigate to your DAR.** Follow the prompts for dbGaP Data Download to submit a Data Access Request (DAR). Include
    as much information as you can, as this will help the Data Access Committee evaluate your application.

--- a/docs/news/2021/04/12/announcing-anvil-cloud-cost-credits-program.mdx
+++ b/docs/news/2021/04/12/announcing-anvil-cloud-cost-credits-program.mdx
@@ -32,7 +32,7 @@ improve human health. We do this by driving cutting-edge research, developing ne
 of genomics on society.
 
 This mission will benefit from AnVIL’s cloud computing resources and large-scale
-genomic [datasets available through the AnVIL]({portalURL}/data/consortia).
+genomic datasets available through the [AnVIL Data Explorer]({browserURL}/datasets).
 
 Applicants should utilize the wealth of data already accessible through AnVIL, or they can upload on AnVIL workspaces
 their own data sets for combined analyses with AnVIL data.

--- a/docs/news/2021/11/22/announcing-anvil-cloud-credits-continued-program.mdx
+++ b/docs/news/2021/11/22/announcing-anvil-cloud-credits-continued-program.mdx
@@ -27,7 +27,7 @@ to [NHGRI’s mission](https://www.genome.gov/about-nhgri/NHGRI-Vision-and-Missi
 of genomics, our mission is to accelerate scientific and medical breakthroughs that improve human health. We do this by
 driving cutting-edge research, developing new technologies, and studying the impact of genomics on society. This mission
 will benefit from AnVIL’s cloud computing resources and large-scale genomic
-datasets [available through the AnVIL]({portalURL}/data/consortia). Applicants should utilize the wealth of
+datasets available through the [AnVIL Data Explorer]({browserURL}/datasets). Applicants should utilize the wealth of
 data already accessible through AnVIL, or they can upload on AnVIL workspaces their own data sets for combined analyses
 with AnVIL data. Projects that propose to upload data for cloud storage without planned analyses to address a NHGRI
 specific research question, or to download AnVIL data for research purposes on local infrastructure are **not responsive**.

--- a/docs/news/2024/09/16/sunsetting-gen3-in-anvil.mdx
+++ b/docs/news/2024/09/16/sunsetting-gen3-in-anvil.mdx
@@ -9,15 +9,15 @@ title: "Sunsetting Gen3 Functionality in AnVIL"
 
 Dear AnVIL Users,
 
-We want to make you aware that starting **October 1, 2024**, the AnVIL Gen3 Commons and free downloadable version of GTEx v8 through Gen3 will be decommissioned. The [AnVIL Data Explorer]({browserURL}/beta-announcement), which has been beta launched and now hosts over 250 AnVIL datasets, will be the recommended method for accessing GTEx data through AnVIL.      
+We want to make you aware that starting **October 1, 2024**, the AnVIL Gen3 Commons and free downloadable version of GTEx v8 through Gen3 will be decommissioned. The [AnVIL Data Explorer]({browserURL}/beta-announcement), which has been beta launched and now hosts over 250 AnVIL datasets, will be the recommended method for accessing GTEx data through AnVIL.
 
-**AnVIL users working in anvil.terra.bio can also access and export GTEx data via DUOS**. See step-by-step instructions [here](https://support.terra.bio/hc/en-us/articles/30873545719451-How-to-access-GTEx-data-in-Terra). 
+**AnVIL users working in anvil.terra.bio can also access and export GTEx data via DUOS**. See step-by-step instructions [here](https://support.terra.bio/hc/en-us/articles/30873545719451-How-to-access-GTEx-data-in-Terra).
 
 More details about the anticipated scope of impact are described below.
 
 ## Scope of impact
 
-- Users will no longer be able to [download GTEx v8](/learn/reference/gtex-v8-free-egress-instructions) for free, and downloads will be subject to Google Cloud Platform egress fees. However, GTEx v8 will still be available for analysis on AnVIL on Terra with access via either the [AnVIL Data Explorer]({browserURL}/datasets) or [AnVIL Dataset Catalog]({portalURL}/data/consortia/GTEx/workspaces).
+- Users will no longer be able to [download GTEx v8](/learn/reference/gtex-v8-free-egress-instructions) for free, and downloads will be subject to Google Cloud Platform egress fees. However, GTEx v8 will still be available for analysis on AnVIL on Terra with access via the [AnVIL Data Explorer]({browserURL}/datasets).
     - See the help articles linked here for more information on how to access data through the [Explorer]({browserURL}/guides) or [Terra](https://support.terra.bio/hc/en-us/articles/4402326091675-Accessing-GTEx-TARGET-TCGA-data).
 - Data export as PFBs from https://gen3.theanvil.io to Cavatica and Terra will no longer be available.
 - Access to data via DRS from https://gen3.theanvil.io will stop.

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -43,7 +43,7 @@ AnVIL provides multiple entry points for data access and analysis, including exe
 
 ## Datasets
 
-AnVIL provides access to key [NHGRI datasets]({portalURL}/data/consortia), such as the CCDG (Centers for Common Disease Genomics), CMG (Centers for Mendelian Genomics), eMERGE (Electronic Medical Records and Genomics), as well as other relevant datasets.
+AnVIL provides access to key [NHGRI datasets]({browserURL}/datasets), such as the CCDG (Centers for Common Disease Genomics), CMG (Centers for Mendelian Genomics), eMERGE (Electronic Medical Records and Genomics), as well as other relevant datasets.
 
 ## Platform Interoperability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "the-anvil",
       "version": "2.9.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "16.0.0",
+        "@databiosphere/findable-ui": "21.4.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2365,9 +2365,9 @@
       "license": "MIT"
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-16.0.0.tgz",
-      "integrity": "sha512-jWgWet5wrITcYOjRDNjm3GoijZCs4cKy5Tr/W5LDCjpTNN2PqvMfruTqB/qHDtpuIXYbKSjwFFfJ8jLd2QFDkg==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-21.4.0.tgz",
+      "integrity": "sha512-lO9fBYT4Jxi8UIMMfAQ3I1JCQ+HjI7CB9RwJ1mhVDb7gL+x5xNKrpXyeOFrNTOSNvMNx5+yi6ULI5ct5BWsWDA==",
       "engines": {
         "node": "20.10.0"
       },
@@ -2382,11 +2382,12 @@
         "isomorphic-dompurify": "0.24.0",
         "ky": "^1.7.2",
         "next": "^14.1.0",
+        "next-auth": "^4.24.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.2.3",
         "react-gtm-module": "2.0.11",
-        "react-idle-timer": "^5.6.2",
+        "react-idle-timer": "^5.7.2",
         "react-window": "1.8.9",
         "uuid": "8.3.2",
         "validate.js": "^0.13.1"
@@ -4731,6 +4732,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "dev": true,
@@ -6708,6 +6718,15 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.1",
@@ -11145,6 +11164,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -12672,6 +12700,38 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next-compose-plugins": {
       "version": "2.2.1",
       "license": "MIT"
@@ -12794,11 +12854,26 @@
       "version": "2.2.4",
       "license": "MIT"
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "peer": true
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -12903,6 +12978,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.0.tgz",
+      "integrity": "sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==",
+      "peer": true,
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "dev": true,
@@ -12925,6 +13009,39 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "peer": true,
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -13243,6 +13360,34 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/preact": {
+      "version": "10.26.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.4.tgz",
+      "integrity": "sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "peer": true,
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
+    "node_modules/preact-render-to-string/node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "peer": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "add-cser-materials": "esrun scripts/add-cser-materials.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "16.0.0",
+    "@databiosphere/findable-ui": "21.4.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import { Footer } from "../components/Home/components/Layout/components/Footer/f
 import { Main } from "../components/Home/components/Layout/components/Main/main";
 import { buildAnalysisPortalCards } from "../components/Home/components/Section/components/SectionAnalysisPortals/common/utils";
 import { CARDS as CLOUD_CARDS } from "../components/Home/components/Section/components/SectionCloudEnvironment/common/content";
-import { buildDatasetCards } from "../components/Home/components/Section/components/SectionDatasets/common/utils";
+import { CARDS as DATASET_CARDS } from "../components/Home/components/Section/components/SectionDatasets/common/utils";
 import { buildCarouselCards } from "../components/Home/components/Section/components/SectionHero/common/utils";
 import { buildPublicationSectionCards } from "../components/Home/components/Section/components/SectionPublications/common/utils";
 import { buildToolsAndWorkflowsCards } from "../components/Home/components/Section/components/SectionExplore/common/utils";
@@ -14,11 +14,11 @@ import { SectionsData, SectionsDataProvider } from "../providers/sectionsData";
 import { HomeView } from "../views/HomeView/homeView";
 
 export const getStaticProps: GetStaticProps<SectionsData> = async () => {
-  const { browserURL, portalURL } = config();
+  const { browserURL } = config();
   const analysisPortalCards = buildAnalysisPortalCards(browserURL);
   const carouselCards = buildCarouselCards();
   const cloudCards = CLOUD_CARDS;
-  const datasetCards = buildDatasetCards(portalURL);
+  const datasetCards = DATASET_CARDS;
   const toolsAndWorkflowsCards = buildToolsAndWorkflowsCards(browserURL);
   const eventCards = buildUpdateSectionCards("events");
   const newsCards = buildUpdateSectionCards("news");

--- a/providers/sectionsData.ts
+++ b/providers/sectionsData.ts
@@ -22,7 +22,7 @@ export interface SectionsData {
   analysisPortalCards: SectionCard[];
   carouselCards: SectionCard[];
   cloudCards: Omit<SectionCard, "links">[];
-  datasetCards: SectionCardWithLink[];
+  datasetCards: Omit<SectionCard, "links">[];
   eventCards: UpdateCard[];
   newsCards: UpdateCard[];
   publicationCards: PublicationCard[];

--- a/site-config/anvil-portal/dev/config.ts
+++ b/site-config/anvil-portal/dev/config.ts
@@ -76,13 +76,18 @@ export function makeConfig(
               url: ROUTES.LEARN,
             },
             {
-              label: "Explorer",
-              target: ANCHOR_TARGET.BLANK,
-              url: `${browserUrl}/datasets`,
-            },
-            {
               label: "Datasets",
               menuItems: [
+                {
+                  description:
+                    "Build, download, and export cross-study cohorts of open and managed access data.",
+                  label: C.LabelIconMenuItem({
+                    iconFontSize: "small",
+                    label: "Explorer",
+                  }),
+                  target: ANCHOR_TARGET.BLANK,
+                  url: `${browserUrl}/datasets`,
+                },
                 {
                   description:
                     "Newly released studies not available in the AnVIL Data Explorer are accessible in DUOS.",

--- a/site-config/anvil-portal/dev/config.ts
+++ b/site-config/anvil-portal/dev/config.ts
@@ -76,23 +76,22 @@ export function makeConfig(
               url: ROUTES.LEARN,
             },
             {
+              label: "Explorer",
+              target: ANCHOR_TARGET.BLANK,
+              url: `${browserUrl}/datasets`,
+            },
+            {
               label: "Datasets",
               menuItems: [
                 {
                   description:
-                    "An open-access view of studies, workspaces, and consortia.",
-                  label: "Catalog",
-                  url: `${portalUrl}/data`,
-                },
-                {
-                  description:
-                    "Build, download, and export cross-study cohorts of open and managed access data.",
+                    "Newly released studies not available in the AnVIL Data Explorer are accessible in DUOS.",
                   label: C.LabelIconMenuItem({
                     iconFontSize: "small",
-                    label: "Explorer",
+                    label: "Early Access Studies",
                   }),
                   target: ANCHOR_TARGET.BLANK,
-                  url: `${browserUrl}/datasets`,
+                  url: "https://duos.broadinstitute.org",
                 },
               ],
               url: "",

--- a/views/HomeView/homeView.tsx
+++ b/views/HomeView/homeView.tsx
@@ -1,25 +1,21 @@
-import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { SectionAnalysisPortals } from "../../components/Home/components/Section/components/SectionAnalysisPortals/sectionAnalysisPortals";
 import { SectionCloudEnvironment } from "../../components/Home/components/Section/components/SectionCloudEnvironment/sectionCloudEnvironment";
 import { SectionDatasets } from "../../components/Home/components/Section/components/SectionDatasets/sectionDatasets";
 import { SectionHero } from "../../components/Home/components/Section/components/SectionHero/sectionHero";
-import { SectionExplore } from "../../components/Home/components/Section/components/SectionExplore/sectionExplore";
 import { SectionPublications } from "../../components/Home/components/Section/components/SectionPublications/sectionPublications";
 import { SectionUpdates } from "../../components/Home/components/Section/components/SectionUpdates/sectionUpdates";
 import { SectionWorkspaces } from "../../components/Home/components/Section/components/SectionWorkspaces/sectionWorkspaces";
 import { SectionDivider } from "../../components/Home/components/Section/section.styles";
-import { SiteConfig } from "../../site-config/common/entities";
+import { SectionExplore } from "../../components/Home/components/Section/components/SectionExplore/sectionExplore";
 
 export const HomeView = (): JSX.Element => {
-  const { config } = useConfig();
-  const portalURL = (config as SiteConfig).portalURL;
   return (
     <>
       <SectionHero />
       <SectionAnalysisPortals />
       <SectionDivider flexItem />
       <SectionExplore />
-      <SectionDatasets portalURL={portalURL} />
+      <SectionDatasets />
       <SectionDivider flexItem />
       <SectionWorkspaces />
       <SectionCloudEnvironment />


### PR DESCRIPTION
Closes #3564.

In the header:
- Removed "Catalog" link within "Datasets" menu,
- Moved "Explorer" link to first menu item,
- Added "Early Access Studies" link within "Datasets" menu with link to [DUOS](https://duos.broadinstitute.org/)

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/05b52360-c45c-453d-ba36-addef6c3ab94" />

On the homepage:

- Removed arrow, link, and hover on the cards in the "Access diverse, open and controlled access, cloud-hosted datasets" section.
- Removed the "Explore Datasets" button.

<img width="1716" alt="image" src="https://github.com/user-attachments/assets/bbeef5cc-4705-4424-bd31-26f928b9cc3d" />

Within the content:

- Removed any links to catalog, and replaced, where possible with links to the explorer (e.g. [current consortia](https://anvilproject.org/consortia#current-consortia)).

