### PR TITLE
feat: update hero ctas (#3562)

### DIFF
--- a/components/Home/components/Section/components/SectionHero/sectionHero.styles.ts
+++ b/components/Home/components/Section/components/SectionHero/sectionHero.styles.ts
@@ -7,9 +7,9 @@ import { textBodyLarge4002Lines } from "@databiosphere/findable-ui/lib/styles/co
 import styled from "@emotion/styled";
 import {
   SectionActions as DefaultActions,
+  sectionGrid,
   SectionHeadline as DefaultHeadline,
   SectionLayout as DefaultLayout,
-  sectionGrid,
 } from "../../section.styles";
 
 export const SectionLayout = styled(DefaultLayout)`
@@ -57,4 +57,9 @@ export const Subhead = styled.h2`
 
 export const CTAs = styled(DefaultActions)`
   flex-direction: row;
+
+  .MuiTypography-text-body-small-400 {
+    margin: 4px 0;
+    text-align: left;
+  }
 `;

--- a/components/Home/components/Section/components/SectionHero/sectionHero.tsx
+++ b/components/Home/components/Section/components/SectionHero/sectionHero.tsx
@@ -1,5 +1,3 @@
-import { ButtonPrimary } from "@databiosphere/findable-ui/lib/components/common/Button/components/ButtonPrimary/buttonPrimary";
-import { ButtonSecondary } from "@databiosphere/findable-ui/lib/components/common/Button/components/ButtonSecondary/buttonSecondary";
 import { Section } from "../../section.styles";
 import { Carousel } from "./components/Carousel/carousel";
 import {
@@ -9,8 +7,20 @@ import {
   SectionLayout,
   Subhead,
 } from "./sectionHero.styles";
+import { Button, Link as MLink, Typography } from "@mui/material";
+import Link from "next/link";
+import {
+  COLOR as BUTTON_COLOR,
+  VARIANT,
+} from "@databiosphere/findable-ui/lib/styles/common/mui/button";
+import { COLOR } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { TEXT_BODY_SMALL_400 } from "@databiosphere/findable-ui/lib/theme/common/typography";
 
-const GET_STARTED = "/learn/get-started";
+const LAUNCH_TERRA = "https://anvil.terra.bio/#workspaces";
 const LEARN_MORE = "/learn";
 
 export const SectionHero = (): JSX.Element => {
@@ -21,8 +31,35 @@ export const SectionHero = (): JSX.Element => {
           <Head>Migrate Your Genomic Research to the Cloud</Head>
           <Subhead>Secure, cost-effective genomic analysis at scale.</Subhead>
           <CTAs>
-            <ButtonPrimary href={GET_STARTED}>Get Started</ButtonPrimary>
-            <ButtonSecondary href={LEARN_MORE}>Learn More</ButtonSecondary>
+            <Button
+              color={BUTTON_COLOR.PRIMARY}
+              component={Link}
+              href={LEARN_MORE}
+              rel={REL_ATTRIBUTE.NO_OPENER}
+              variant={VARIANT.CONTAINED}
+            >
+              Learn More
+            </Button>
+            <Button
+              color={BUTTON_COLOR.SECONDARY}
+              component={MLink}
+              href={LAUNCH_TERRA}
+              rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+              sx={{ display: { sm: "block", xs: "none" } }}
+              target={ANCHOR_TARGET.BLANK}
+              variant={VARIANT.CONTAINED}
+            >
+              Launch Terra
+            </Button>
+            <Typography
+              color={COLOR.INK_LIGHT}
+              component="div"
+              sx={{ display: { sm: "block", xs: "none" } }}
+              variant={TEXT_BODY_SMALL_400}
+            >
+              <div>AnVIL&apos;s cloud</div>
+              <div>compute environment</div>
+            </Typography>
           </CTAs>
         </Headline>
         <Carousel />


### PR DESCRIPTION
Closes #3562.

- Updated hero CTA with "Learn More", "Launch Terra" buttons, and text "AnVIL's cloud compute environment".
- Includes package.json update with latest `findable-ui` version.
 
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/59e045ab-d76f-48e9-8895-e42f068dc9f4" />
