### PR TITLE
content: add als compute consortium to the anvil consortium page (#3568)

### DIFF
--- a/docs/consortia.mdx
+++ b/docs/consortia.mdx
@@ -3,6 +3,7 @@ title: "Data Consortia"
 ---
 
 
+
 import { Card, Consortia } from "../components";
 import DataIngestionChart from "../components/Consortia/CSER/components/DataIngestionChart/dataIngestionChart";
 
@@ -15,6 +16,10 @@ AnVIL hosts data from the following programs and also allows users to submit the
 ## Current Consortia
 
 <Consortia gridSx={{ gap: 4 }}>
+  <Card
+    text="The ALS Compute Project centralizes whole genome sequencing (WGS) data from major ALS and FTD sequencing efforts in the United States and beyond, creating a comprehensive repository of genomic and phenotypic data. By harmonizing datasets within a single Cloud environment, it enhances accessibility, reduces inefficiencies, and strengthens collaboration. Available through the AnVIL platform, this resource empowers researchers worldwide to explore large-scale data, develop new disease theories, and drive breakthroughs in understanding ALS, FTD, and other motor neuron diseases. Participants: 12,638."
+    title="ALS Compute"
+  />
   <Card
     cardActions={[
       {


### PR DESCRIPTION
Closes #3568.

<img width="1668" alt="image" src="https://github.com/user-attachments/assets/09345942-fecb-4821-b7e2-7cf462d95367" />
