### PR TITLE
fix: update duos link to point directly to the anvil data library (#3603)

### DIFF
--- a/docs/learn/find-data.mdx
+++ b/docs/learn/find-data.mdx
@@ -8,7 +8,7 @@ overview:
       - label: "AnVIL Data Explorer"
         url: https://explore.anvilproject.org/datasets
       - label: "Early Access Studies"
-        url: https://duos.broadinstitute.org
+        url: https://duos.org/datalibrary/AnVIL
   - label: "Access Data"
     links:
       - /learn/find-data/requesting-data-access

--- a/site-config/anvil-portal/dev/config.ts
+++ b/site-config/anvil-portal/dev/config.ts
@@ -96,7 +96,7 @@ export function makeConfig(
                     label: "Early Access Studies",
                   }),
                   target: ANCHOR_TARGET.BLANK,
-                  url: "https://duos.broadinstitute.org",
+                  url: "https://duos.org/datalibrary/AnVIL",
                 },
               ],
               url: "",


### PR DESCRIPTION
Closes #3603.