### PR TITLE
content: fix typo in set-up-a-data-model.mdx

### DIFF
--- a/docs/learn/data-submitters/submission-guide/set-up-a-data-model.mdx
+++ b/docs/learn/data-submitters/submission-guide/set-up-a-data-model.mdx
@@ -80,7 +80,7 @@ Note that data models for submitted datasets are not restricted to what is inclu
 * [**File**](https://docs.google.com/spreadsheets/d/1D0L5wm5pnpLKYqakYm9tyy-VmP5oJmGR/edit?gid=462062238#gid=462062238) **(strongly recommended):** Contains information for files associated with the study. Example data includes DRS ID, filename, and file type.
   * The `file_id` (first column) is required.
   * It is strongly recommended that the table includes a `BioSample.biosample_id` column to link the biosample id between tables.
-  * AnVIl will add DRS URIs for object files as part of the ingest process.
+  * AnVIL will add DRS URIs for object files as part of the ingest process.
 
 
 ### Optional Tables


### PR DESCRIPTION
Noticed a typo (AnVI1) when presenting this page at an internal meeting, fixed to AnVIL!