### PR TITLE
content: add cloud use statement

### DIFF
--- a/docs/overview/security.mdx
+++ b/docs/overview/security.mdx
@@ -34,3 +34,8 @@ Instead, all Platform Services and third-party applications must be approved by 
 
 To gain access to some datasets, you may be required to provide a Cloud Use Statement in your access request. You can modify the following to suit your needs, but we recommend exploring other examples for specific use cases. For example, [PRIMED Cloud Use and Provider Statements](https://docs.google.com/document/d/1VVqDxzzdRRVSOOYwDx4eszne_SZzF77B/preview?tab=t.0#heading=h.4gy3ud9t2hnv).
 
+**Name of Cloud Provider:** The NHGRI Analysis, Visualization, and Informatics Lab-space (AnVIL)
+
+**Type of Cloud Provider:** Commercial, Platform as a Service (PaaS)
+
+**Cloud Use Statement:** The NHGRI AnVIL (www.anvilproject.org) is a cloud-based infrastructure currently provided by Google Cloud Platform where researchers can search, find, access, share, cross-link, and compute on large scale datasets. It provides tools, applications, and workflows to enable those capabilities in secure workspaces. Workspaces are provided by Terra, hosted and operated by the Broad Institute. AnVIL's datasets and compute infrastructure are secured in accordance with the industry best practices, the NIST 800-53 Moderate security controls following the FedRAMP standard. Most Platform Services maintain an Authority to Operate (ATO) from a US Federal Government Authorizing Official. All Platform Services and third-party applications on AnVIL are approved by the Broad Institute Office of the Chief Information Security Officer (CISO) who functions as the AnVIL Authorizing Official (AO) and who reviews the security package of each system to ensure that AnVIL’s standard security baseline is met.


### PR DESCRIPTION
Hi folks,

We got a request in the help forum about Cloud Use Statement template text. See https://help.anvilproject.org/t/dbgap-access-sequencing-data/289/6

We've had [this doc](https://docs.google.com/document/d/1BmGP7vt0LP_-_nmhabXR5HcWx2dzxFmsj4P3B6O65T0/edit?pli=1&tab=t.0) reviewed internally and would love to make it more widely accessible to users.

Please let us know if there are any issues with this, or it belongs somewhere else. Thanks!!