### PR TITLE
feat: gregor blog post to news (#3639)

### DIFF
--- a/docs/news/2025/07/25/gregor-consortium-data-release.mdx
+++ b/docs/news/2025/07/25/gregor-consortium-data-release.mdx
@@ -1,0 +1,34 @@
+---
+date: "2025-07-25"
+description: "The third data release from the GREGoR Consortium (Genomics Research to Elucidate the Genetics of Rare diseases) is now available on AnVIL."
+featured: true
+title: "Data Release - GREGoR Consortium"
+---
+
+<NewsHero {...frontmatter} />
+
+The third data release from the [GREGoR Consortium](https://gregorconsortium.org) (Genomics Research to Elucidate the Genetics of Rare diseases) is now available on AnVIL for controlled access by the broader scientific community. Additionally, the GREGoR Consortium has developed a publicly available open-access [variant browser](https://variants.gregorconsortium.org) that enables searches for variants of interest across the Consortium joint, short-read whole genome callset.
+
+The GREGoR Consortium has assembled a dataset of broad utility. All participants have broadly consented for General Research Use or Health, Medical, or Biomedical research. The Consortium data aligns with [the GREGoR Data Model](https://github.com/UW-GAC/gregor_data_models), designed to provide context and information to support analysis and secondary use of the data. Additional documentation, including how to apply for access, is available on the GREGoR Consortium’s [Data webpage](https://gregorconsortium.org/data).
+
+This second data release consists of 7,394 participants and more than 3,000 families. For these participants, the GREGoR Consortium Dataset includes family, pedigree, and phenotype information. Genomic data, such as short-read DNA and RNA sequencing data, are available for the majority of GREGoR participants (see table below). The GREGoR Dataset also includes candidate genetic findings identified by participating [GREGoR Research Centers](https://gregorconsortium.org/about/gregor-centers). In this release, a subset of short-read whole genome sequencing data is uniformly processed by the GREGoR Data Coordinating Center, which is used to generate a Consortium joint callset for small variants (SNVs and Indels).
+
+### Available Data
+
+|  | Release R01 | Release R02 | Release R03 |
+| :--- | :--- | :--- | :--- |
+| Release Date | September 2023 | November 2024 | July 2025 |
+| Participants | 2,512 (1,130 affected) | 7,394 (3,555 affected) | 8,840 (4,127 affected) |
+| Families | 990 | 3,059 | 3,610 |
+| Short-read whole exomes | 997 | 2,242 | 2,284 |
+| Short-read whole genomes | 1,441 | 5,180 | 6,535 |
+| Long-read whole genomes | 0 | 214 | 1,772 |
+| RNA-seq files | 192 | 539 | 860 |
+| Genome Build | GRCh38 | GRCh38 | GRCh38 |
+
+### Acknowledgements and attribution
+
+The GREGoR Acknowledgements and attribution statement are available at the [dbGaP study page](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs003047.v3.p2#attribution-section). You can learn more about GREGoR at https://gregorconsortium.org.
+
+
+


### PR DESCRIPTION
Closes #3639.

This pull request adds a new news article announcing the third data release from the GREGoR Consortium. The article provides detailed information about the release, including data availability, participant details, and links to related resources.

### New content addition:

* [`docs/news/2025/07/25/gregor-consortium-data-release.mdx`](diffhunk://#diff-4d91b496c9eb241320dfd50b1547408bec7def3817dfe9855f89166a51ae0675R1-R34): Added a news article titled "Data Release - GREGoR Consortium" announcing the third data release. The article includes a description of the dataset, participant statistics, available genomic data, and links to resources such as the variant browser, data model, and access documentation. Acknowledgements and attribution details are also provided.

<img width="1728" height="933" alt="image" src="https://github.com/user-attachments/assets/83dce83c-64f0-4b24-8e7b-074ddc83cb0a" />
