### PR TITLE
feat: temporarily pause auto-rotate homepage carousel (#3653)

### DIFF
--- a/components/Home/components/Section/components/SectionHero/components/Carousel/hooks/useInteractiveCarousel.ts
+++ b/components/Home/components/Section/components/SectionHero/components/Carousel/hooks/useInteractiveCarousel.ts
@@ -31,7 +31,7 @@ export function useInteractiveCarousel(): UseInteractiveCarousel {
   const swipeInteraction = useSwipeInteraction(
     interactiveIndexes.length,
     true,
-    8000
+    0
   );
   return {
     interactiveCards: carouselCards,


### PR DESCRIPTION
Closes #3653.

This pull request makes a minor adjustment to the carousel interaction logic. The swipe interaction timeout has been set to zero, which disables the automatic swipe feature.