### PR TITLE
content: added all of us + anvil event #3664

### DIFF
--- a/docs/events/ashg2025-all-of-us-anvil-imputation-service-workshop.mdx
+++ b/docs/events/ashg2025-all-of-us-anvil-imputation-service-workshop.mdx
@@ -1,0 +1,23 @@
+---
+author: "AnVIL"
+conference: "ASHG 2025"
+description: "Improve the completeness and accuracy of your datasets with the All of Us + AnVIL Imputation Service"
+eventType: "Digital Workshop"
+featured: false
+hashtag: #ashg2025
+location: "Location Virtual"
+sessions:
+  [{ sessionStart: "27 Aug 2025 12:00 PM" }]
+timezone: "America/New_York"
+title: "All of Us & AnVIL Imputation Service"
+---
+
+<EventsHero {...frontmatter} />
+
+The NIH’s All of Us Research Program and NHGRI’s Genomic Analysis Visualization and Informatics Lab Space (AnVIL) are collaborating to build an imputation service, backed by the largest imputation panel in the world. The panel is derived from whole genome data of over 515,000 participants, including more than 250,000 from non-European ancestries. Attendees will hear about the development of the service, learn to submit data to the service for imputation, and perform a down stream analysis calculating a polygenic risk score on data imputed with the service.
+
+Participants will be provided with a test vcf to submit to the service, and will be instructed in the use of a dedicated command line tool for interacting with the service. PRS calculation will be performed using PLINK.
+
+#### Prerequisites (if any)
+Register for the workshop at https://learning.ashg.org/products/workshop-all-of-us-anvil-imputation-service
+


### PR DESCRIPTION
#### Ticket
#3664 

#### Updates

This pull request adds documentation for a new digital workshop event focused on the All of Us & AnVIL Imputation Service at ASHG 2025. The documentation provides key details about the workshop, including its description, schedule, and prerequisites.

Event documentation:

* Added a new event file `docs/events/ashg2025-all-of-us-anvil-imputation-service-workshop.mdx` with metadata and a detailed description of the All of Us & AnVIL Imputation Service workshop at ASHG 2025, including session time, location, and prerequisites for attendees.