### PR TITLE
content: added all of us + anvil imputation service news #3667

### DIFF
--- a/docs/news/2025/08/25/all-of-us-anvil-imputation-service.mdx
+++ b/docs/news/2025/08/25/all-of-us-anvil-imputation-service.mdx
@@ -9,4 +9,4 @@ title: "Introducing the All of Us + AnVIL Imputation Service"
 
 The Broad Institute’s Data Sciences Platform has launched the All of Us + AnVIL Imputation Service. This is the first in a new suite of cloud-based scientific services, designed to make large-scale genomic research faster, more accurate, and more inclusive.
 
-You can learn more about the All of Us + AnVIL Imputation Service at https://terra.bio/introducing-the-all-of-us-anvil-imputation-service.
+You can learn more about the All of Us + AnVIL Imputation Service at [Introducing the All of Us + AnVIL Imputation Service](https://terra.bio/introducing-the-all-of-us-anvil-imputation-service).

--- a/docs/news/2025/08/25/all-of-us-anvil-imputation-service.mdx
+++ b/docs/news/2025/08/25/all-of-us-anvil-imputation-service.mdx
@@ -10,6 +10,3 @@ title: "Introducing the All of Us + AnVIL Imputation Service"
 The Broad Institute’s Data Sciences Platform has launched the All of Us + AnVIL Imputation Service. This is the first in a new suite of cloud-based scientific services, designed to make large-scale genomic research faster, more accurate, and more inclusive.
 
 You can learn more about the All of Us + AnVIL Imputation Service at https://terra.bio/introducing-the-all-of-us-anvil-imputation-service.
-
-
-

--- a/docs/news/2025/08/25/all-of-us-anvil-imputation-service.mdx
+++ b/docs/news/2025/08/25/all-of-us-anvil-imputation-service.mdx
@@ -9,4 +9,4 @@ title: "Introducing the All of Us + AnVIL Imputation Service"
 
 The Broad Institute’s Data Sciences Platform has launched the All of Us + AnVIL Imputation Service. This is the first in a new suite of cloud-based scientific services, designed to make large-scale genomic research faster, more accurate, and more inclusive.
 
-You can learn more about the All of Us + AnVIL Imputation Service at [Introducing the All of Us + AnVIL Imputation Service](https://terra.bio/introducing-the-all-of-us-anvil-imputation-service).
+You can learn more about the All of Us + AnVIL Imputation Service by [reading the full announcement](https://terra.bio/introducing-the-all-of-us-anvil-imputation-service).

--- a/docs/news/2025/09/25/all-of-us-anvil-imputation-service.mdx
+++ b/docs/news/2025/09/25/all-of-us-anvil-imputation-service.mdx
@@ -1,0 +1,15 @@
+---
+date: "2025-08-25"
+description: "The Broad Institute’s Data Sciences Platform has launched the All of Us + AnVIL Imputation Service."
+featured: false
+title: "Introducing the All of Us + AnVIL Imputation Service"
+---
+
+<NewsHero {...frontmatter} />
+
+The Broad Institute’s Data Sciences Platform has launched the All of Us + AnVIL Imputation Service. This is the first in a new suite of cloud-based scientific services, designed to make large-scale genomic research faster, more accurate, and more inclusive.
+
+You can learn more about the All of Us + AnVIL Imputation Service at https://terra.bio/introducing-the-all-of-us-anvil-imputation-service.
+
+
+


### PR DESCRIPTION
#### Ticket
#3667

#### Updates
This pull request adds a news article announcing the launch of the All of Us + AnVIL Imputation Service by the Broad Institute’s Data Sciences Platform. The article provides a brief overview and a link for more information.

- Documentation:
  * Added a new news post in `docs/news/2025/08/25/all-of-us-anvil-imputation-service.mdx` announcing the All of Us + AnVIL Imputation Service and providing a link for further details.