### PR TITLE
content: added gatf data release to news #3670

### DIFF
--- a/docs/news/2025/08/25/gafk-data-version-5-data-release.mdx
+++ b/docs/news/2025/08/25/gafk-data-version-5-data-release.mdx
@@ -1,0 +1,24 @@
+---
+date: "2025-08-25"
+description: "Children’s Mercy, a nationally recognized and leading pediatric health system in Kansas City, released new data to help experts find breakthrough answers and treatments for rare, pediatric genetic conditions."
+featured: true
+title: "Genomic Answers for Kids Version 5 Data Release on the AnVIL Platform"
+---
+
+<NewsHero {...frontmatter} />
+
+Children’s Mercy, a nationally recognized and leading pediatric health system in Kansas City, released new data to help experts find breakthrough answers and treatments for rare, pediatric genetic conditions. Genomic Answers for Kids (GA4K), a research initiative of the Children’s Mercy Research Institute, is a pediatric data repository to facilitate the search for answers and novel treatments for pediatric genetic conditions. The study generates genomic data and collects health information, including phenotypic and family history information, for thousands of children and their families. Controlled-access data is available for the study of pediatric disease.
+
+The new data release includes:
+
+- Over 2,000 long-read genome sequences
+- Over 12,000 short-read genome and exome analyses
+- Nearly 400 snapshots of patient transcriptomes and epigenomes in individual cells using single-cell RNA (scRNA) and sc open chromatin (scATAC)
+- Over 3,000 bulk whole genome bisulphite genome sequences for methylome interpretation
+- Over 200 functional assessments in available patient tissues using full length cDNA sequences by IsoSeq (PacBio) methodology
+
+Access requests for this controlled data is available through dbGaP under accession [https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002206.v5.p1](phs002206.v5.p1) and the data is available at https://explore.anvilproject.org/datasets or https://duos.org/datalibrary/anvil.
+
+Variants identified in Genomic Answers for Kids are also deposited in the open access [Beacon Network](https://beacon-network.org/#/).
+
+To learn more about the Children’s Mercy GA4K pediatric data repository – a study that generates genomic data and collects phenotypic and family history information to help thousands of kids and their loved ones – visit [childrensmercy.org](https://www.childrensmercy.org/).


### PR DESCRIPTION
#### Ticket
Closes #3670 

#### Updates

This pull request adds a new news article announcing the Genomic Answers for Kids Version 5 data release on the AnVIL platform. The article highlights the scale and types of new data available for pediatric genetic research and provides links for data access and further information.

Content addition:

* Added a new news article at `docs/news/2025/08/25/gafk-data-version-5-data-release.mdx` describing the GA4K Version 5 data release, including details on data types, access instructions, and relevant links.