### PR TITLE
content: added card data release to news #3672

### DIFF
--- a/docs/news/2025/08/25/card-data-release-2.mdx
+++ b/docs/news/2025/08/25/card-data-release-2.mdx
@@ -1,0 +1,31 @@
+---
+date: "2025-08-25"
+description: "The second release of long-read DNA sequencing of brain tissue samples from the NIH Center for Alzheimer's and Related Dementias (CARD) Long Read Sequencing group is now available on AnVIL for controlled access through dgGaP."
+featured: false
+title: "Center for Alzheimer's and Related Dementias (CARD) Data Release 2 on the AnVIL Platform"
+---
+
+<NewsHero {...frontmatter} />
+
+The second release of long-read DNA sequencing of brain tissue samples from the NIH Center for Alzheimer's and Related Dementias (CARD) [Long Read Sequencing group](https://card.nih.gov/research-programs/long-read-sequencing) is now available on AnVIL for controlled access through dgGaP. This data release includes 206 samples from a North American Brain Expression Consortium study (NABEC, dbGaP:phs001300) and 155 from the DIRP NIMH Human Brain Collection Core (HBCC:phs000979). 
+
+Access requests for these controlled datasets are available through dbGaP under accessions [phs001300.v5.p1](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001300.v5.p1) and [phs000979.v4.p2](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000979.v4.p2) and the data is available at https://explore.anvilproject.org/datasets or https://duos.org/datalibrary/anvil.
+
+Nanopore sequencing data is provided in mapped BAM format that includes read phasing assignment and 5-methylcytosine (5mC) calls. In addition to sequencing data, this data release includes: haplotype-resolved assemblies, structural and small variant calls, as well as methylation calls for all 361 neurologically ‘normal’ prefrontal cortex ( and cortex ) brain tissue samples. All of these data were produced on Terra using Nanopore Analysis Pipeline (NAPU) workflows which can be found [here](https://dockstore.org/organizations/NIHCARD), also see this [publication](https://www.nature.com/articles/s41592-023-01993-x) for more information about the NAPU workflow.
+
+
+
+CARD aims to build a framework for the large-scale application of Oxford Nanopore sequencing while filling knowledge gaps about genomic variation in Alzheimer’s disease and other neurological disorders. CARD makes its long-read sequencing data, protocols, and pipelines [open access for other researchers](https://card.nih.gov/data-resources/access-data). To this end, CARD has also provided a catalogue of haplotype-resolved small and structural variants and aggregated methylation for each cohort in this data release. These data are used to investigate how genomic variants are associated with gene expression and epigenetic modifications in brain tissue in this preprint [Long-read sequencing of hundreds of diverse brains provides insight into the impact of structural variation on gene expression and DNA methylation](https://www.biorxiv.org/content/10.1101/2024.12.16.628723v1.full). 
+
+|                                              | Release 1 | Release 2 |
+|----------------------------------------------|:----------|:----------|
+| Brain Tissue Samples                         | 14        | 361       |
+| Cell Lines                                   | 3         | 0         |
+| Long-read phased genomes                     | 17        | 361       |
+| Small variant callsets                       | 17        | 361       |
+| Structural variant callsets                  | 17        | 361       |
+| Methylation callsets haplotype-resolved      | 17        | 361       |
+
+_CARD is a collaboration between the National Institute of Neurological Disorders and Stroke (NINDS) and the National Institute on Aging (NIA). Learn more about CARD’s long-read sequencing efforts for AD/ADRD [here](https://www.genomeweb.com/sequencing/nih-researchers-deploy-nanopore-sequencing-large-scale-alzheimers-study#.ZBRJZuyZPjn) and [here](https://card.nih.gov/research-programs/long-read-sequencing)._
+
+_The CARD long-read consortium includes researchers from National Institute on Aging, UC Santa Cruz Genomics Institute, National Cancer Institute, National Human Genome Research Institute, Baylor College of Medicine, Johns Hopkins University, University of Southern California and Northeastern University College of engineering._


### PR DESCRIPTION
#### Ticket
Closes #3672.

#### Updates

This pull request adds a new news post announcing the second release of long-read DNA sequencing data from the Center for Alzheimer's and Related Dementias (CARD) on the AnVIL platform. The post provides details on the datasets, access instructions, and the scientific context of the release.

New data release announcement:

* Added `card-data-release-2.mdx` to the `docs/news/2025/08/25/` directory, announcing the availability of CARD Data Release 2 on AnVIL, including dataset descriptions, access instructions, and scientific background.