### PR TITLE
content: added imputation service to carousel #3689

### DIFF
--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -121,5 +121,16 @@ export function buildCarouselCards(): SectionCard[] {
       title:
         "The Galaxy platform for accessible, reproducible and collaborative biomedical analyses: 2020 update",
     },
+    {
+      links: [
+        {
+          label: ACTION_LABEL.LEARN_MORE,
+          target: ANCHOR_TARGET.SELF,
+          url: "/news/2025/08/25/all-of-us-anvil-imputation-service",
+        },
+      ],
+      text: "The Broad Institute's Data Sciences Platform has launched the All of Us + AnVIL Imputation Service.",
+      title: "Introducing the All of Us + AnVIL Imputation Service",
+    },
   ];
 }


### PR DESCRIPTION
#### Ticket

Closes #3689.

#### Changes

This pull request adds a new carousel card to the homepage section, highlighting the launch of the All of Us + AnVIL Imputation Service by the Broad Institute's Data Sciences Platform.

Homepage content update:

* Added a new entry to the carousel in `buildCarouselCards` with information and a "Learn More" link about the All of Us + AnVIL Imputation Service.

<img width="1722" height="534" alt="image" src="https://github.com/user-attachments/assets/c81bf85c-ae84-4736-b51d-a3043cc4346f" />
