### PR TITLE
fix: updated imputation service pri #3689

### DIFF
--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -16,6 +16,17 @@ export function buildCarouselCards(): SectionCard[] {
     {
       links: [
         {
+          label: ACTION_LABEL.LEARN_MORE,
+          target: ANCHOR_TARGET.SELF,
+          url: "/news/2025/08/25/all-of-us-anvil-imputation-service",
+        },
+      ],
+      text: "The Broad Institute's Data Sciences Platform has launched the All of Us + AnVIL Imputation Service.",
+      title: "Introducing the All of Us + AnVIL Imputation Service",
+    },
+    {
+      links: [
+        {
           label: ACTION_LABEL.PAPER,
           url: "https://www.cell.com/ajhg/fulltext/S0002-9297(24)00379-3",
         },
@@ -120,17 +131,6 @@ export function buildCarouselCards(): SectionCard[] {
       text: "AnVIL has access to full Galaxy capabilities, a computational workbench used by thousands of scientists to analyze biomedical data.",
       title:
         "The Galaxy platform for accessible, reproducible and collaborative biomedical analyses: 2020 update",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          target: ANCHOR_TARGET.SELF,
-          url: "/news/2025/08/25/all-of-us-anvil-imputation-service",
-        },
-      ],
-      text: "The Broad Institute's Data Sciences Platform has launched the All of Us + AnVIL Imputation Service.",
-      title: "Introducing the All of Us + AnVIL Imputation Service",
     },
   ];
 }


### PR DESCRIPTION
#### Ticket

#3689 

#### Changes

This pull request updates the carousel cards displayed on the home section by reordering the "All of Us + AnVIL Imputation Service" announcement card to appear earlier in the list. No other functional changes were made. 

- **Carousel Card Reordering:**
  * Moved the "Introducing the All of Us + AnVIL Imputation Service" card to appear at the top of the carousel cards array in `buildCarouselCards` within `utils.ts`. [[1]](diffhunk://#diff-e6b819cab4350f55c7b0140e6689f422590acb49b2efe3ee26de2e3f42ffef36R16-R26) [[2]](diffhunk://#diff-e6b819cab4350f55c7b0140e6689f422590acb49b2efe3ee26de2e3f42ffef36L124-L134)