### PR TITLE
feat: block gregor pages if the feature flag is not set (#3716)

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -8,6 +8,7 @@ import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import { serialize } from "next-mdx-remote/serialize";
 import { GetStaticPathsResult } from "next/types";
+import Error from "next/error";
 import remarkGfm from "remark-gfm";
 import { ContentView, Nav, NavBarHero } from "../components";
 import { ContentEnd } from "../components/Layout/components/Content/components/ContentEnd/contentEnd";
@@ -47,7 +48,14 @@ const Page = ({
   slug,
 }: DocPageProps): JSX.Element => {
   const isGREGoREnabled = useFeatureFlag("gregor");
+
+  if (!isGREGoREnabled && isGREGoRConsortiumPage(slug)) {
+    // If the page is for the GREGoR consortium and the feature is disabled, return a 404.
+    return <Error statusCode={404} />;
+  }
+
   if (!mdxSource) return <></>;
+
   return (
     <ContentView
       content={
@@ -115,6 +123,16 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export default Page;
 
 Page.Main = Main;
+
+/**
+ * Checks if the slug is for the GREGoR consortium page(s).
+ * @param slug - Slug.
+ * @returns True if the slug is for the GREGoR consortium page(s), false otherwise.
+ */
+function isGREGoRConsortiumPage(slug?: string[]): boolean {
+  if (!slug) return false;
+  return slug.length === 2 && slug[0] === "consortia" && slug[1] === "gregor";
+}
 
 /**
  * Filters conflicting paths with other page static paths.


### PR DESCRIPTION
Closes #3716.

This pull request introduces logic to conditionally display GREGoR consortium pages based on a feature flag, ensuring that users cannot access these pages unless the feature is enabled. The most important changes are grouped below:

Feature flag enforcement for GREGoR consortium pages:

* Added an early return in the `Page` component to display a 404 error (`<Error statusCode={404} />`) when the GREGoR feature flag is disabled and the requested page matches the GREGoR consortium path. ([pages/[...slug].tsxR51-R58](diffhunk://#diff-5e5186614071390e5a8824f814c2a49cd4083adc99ada4220e546a421676ca2aR51-R58))
* Implemented the `isGREGoRConsortiumPage` helper function to identify GREGoR consortium pages based on the URL slug. ([pages/[...slug].tsxR127-R136](diffhunk://#diff-5e5186614071390e5a8824f814c2a49cd4083adc99ada4220e546a421676ca2aR127-R136))

Dependency update:

* Imported the `Error` component from `next/error` to support rendering the 404 error page. ([pages/[...slug].tsxR11](diffhunk://#diff-5e5186614071390e5a8824f814c2a49cd4083adc99ada4220e546a421676ca2aR11))