### PR TITLE
feat: add anvil demos january 2026 (#3690)

### DIFF
--- a/docs/events/anvil2026-january-demos.mdx
+++ b/docs/events/anvil2026-january-demos.mdx
@@ -1,0 +1,40 @@
+---
+conference: "AnVIL 2026"
+description: "Learn new ways to use AnVIL and ask questions!"
+eventType: "AnVIL Demos"
+featured: true
+hashtag: "#anvildemos"
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "21 January 2026 10:00 AM",
+      sessionEnd: "21 January 2026 11:00 AM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL Demos"
+---
+
+<EventsHero {...frontmatter} />
+
+## What are AnVIL Demos?
+
+AnVIL Demos are a series of virtual meetings that highlight what you can do on the [NHGRI](https://www.genome.gov) Analysis, Visualization, and Informatics Lab-space (AnVIL), a cloud-based computing platform for genomic data science. AnVIL Demos will start out with a 30-minute demonstration on the platform followed by open time for Q&A and user support.
+
+In the demos, presenters will highlight anything from a capability of the platform to a scientific analysis powered by AnVIL. If you’re interested in showcasing how you use AnVIL at a future AnVIL Demos session, reach out to [Natalie Kucher]({natalieKucher}).
+
+View our past AnVIL Demos on our YouTube playlist (https://www.youtube.com/playlist?list=PL6aYJ_0zJ4uC978C57P3TgAAfB38uy58E).
+
+After the demo, we’ll open up the floor to answer questions about the demo and to answer any other questions you might have about AnVIL.
+
+## Prerequisites
+
+Register for any of the upcoming AnVIL Demos using this [Google Form](https://forms.gle/7CcaLE9AM7FrYqpP7) and post any questions you have to the [AnVIL Support Forum]({anvilHelpURL}).
+
+## Event Details
+
+- How to register: Register using this [Google Form](https://forms.gle/7CcaLE9AM7FrYqpP7).
+- Contact Info: Please contact [Natalie Kucher]({natalieKucher}) with any questions.
+- Past AnVIL Demos: Find past recordings on our [YouTube playlist](https://www.youtube.com/playlist?list=PL6aYJ_0zJ4uC978C57P3TgAAfB38uy58E).
+- Get help at the [AnVIL Support Forum]({anvilHelpURL}).


### PR DESCRIPTION
Closes #3690.

<img width="1115" height="1231" alt="image" src="https://github.com/user-attachments/assets/755c0965-4334-49e4-b6ba-feee3961efa6" />

This pull request adds a new event documentation page for the "AnVIL Demos" scheduled in January 2026. The page provides details about the event, including its purpose, registration information, and ways to get support and view past demos.

Event documentation:

* Created a new event page `docs/events/anvil2026-january-demos.mdx` with metadata for the "AnVIL Demos" virtual event, including conference name, description, featured status, session schedule, timezone, and location.

Event details and resources:

* Added sections explaining the format and purpose of AnVIL Demos, including a description of the demo and Q&A structure.
* Provided registration instructions and links to the Google Form, support forum, and YouTube playlist for past demos.
* Included contact information for event inquiries and instructions for users interested in presenting at future sessions.