### PR TITLE
feat: add anvil demos march 2026 (#3692)

### DIFF
--- a/docs/events/anvil2026-march-demos.mdx
+++ b/docs/events/anvil2026-march-demos.mdx
@@ -1,0 +1,21 @@
+---
+conference: "AnVIL 2026"
+description: "Learn new ways to use AnVIL and ask questions!"
+eventType: "AnVIL Demos"
+featured: true
+hashtag: "#anvildemos"
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "18 March 2026 10:00 AM",
+      sessionEnd: "18 March 2026 11:00 AM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL Demos"
+---
+
+<EventsHero {...frontmatter} />
+
+<AnVIL2026Demos />


### PR DESCRIPTION
Closes #3692.

This pull request adds a new event page for the "AnVIL Demos" session at the AnVIL 2026 conference. The page includes key event details, session timing, and components for displaying event information.

Event page addition:

* Created `docs/events/anvil2026-march-demos.mdx` to provide details for the "AnVIL Demos" session, including conference name, description, featured status, hashtag, location, session times, timezone, and title.
* Integrated `EventsHero` and `AnVIL2026Demos` components to present the event information and session content.