### PR TITLE
feat: add anvil demos april 2026 (#3693)

### DIFF
--- a/docs/events/anvil2026-april-demos.mdx
+++ b/docs/events/anvil2026-april-demos.mdx
@@ -1,0 +1,21 @@
+---
+conference: "AnVIL 2026"
+description: "Learn new ways to use AnVIL and ask questions!"
+eventType: "AnVIL Demos"
+featured: true
+hashtag: "#anvildemos"
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "15 April 2026 10:00 AM",
+      sessionEnd: "15 April 2026 11:00 AM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL Demos"
+---
+
+<EventsHero {...frontmatter} />
+
+<AnVIL2026Demos />


### PR DESCRIPTION
Closes #3693.

This pull request adds a new documentation page for the upcoming "AnVIL Demos" event in April 2026. The page provides event details and integrates components to display the event information.

Event documentation:

* Created a new file `docs/events/anvil2026-april-demos.mdx` with metadata and session details for the "AnVIL Demos" event, including conference name, description, date, location, and featured status.
* Integrated the `<EventsHero />` and `<AnVIL2026Demos />` components to render event-specific content on the page.