### PR TITLE
feat: add anvil demos july 2026 (#3696)

### DIFF
--- a/docs/events/anvil2026-july-demos.mdx
+++ b/docs/events/anvil2026-july-demos.mdx
@@ -1,0 +1,21 @@
+---
+conference: "AnVIL 2026"
+description: "Learn new ways to use AnVIL and ask questions!"
+eventType: "AnVIL Demos"
+featured: true
+hashtag: "#anvildemos"
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "15 July 2026 10:00 AM",
+      sessionEnd: "15 July 2026 11:00 AM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL Demos"
+---
+
+<EventsHero {...frontmatter} />
+
+<AnVIL2026Demos />


### PR DESCRIPTION
Closes #3696.

This pull request adds a new event page for the "AnVIL Demos" session at the AnVIL 2026 conference. The page includes event metadata, session details, and integrates relevant components for display.

New event documentation:

* Added `docs/events/anvil2026-july-demos.mdx` to document the "AnVIL Demos" event, including conference info, session time, location, and featured status.
* Integrated `EventsHero` and `AnVIL2026Demos` components for improved event presentation.