### PR TITLE
feat: add anvil demos august 2026 (#3697)

### DIFF
--- a/docs/events/anvil2026-august-demos.mdx
+++ b/docs/events/anvil2026-august-demos.mdx
@@ -1,0 +1,21 @@
+---
+conference: "AnVIL 2026"
+description: "Learn new ways to use AnVIL and ask questions!"
+eventType: "AnVIL Demos"
+featured: true
+hashtag: "#anvildemos"
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "19 August 2026 10:00 AM",
+      sessionEnd: "19 August 2026 11:00 AM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL Demos"
+---
+
+<EventsHero {...frontmatter} />
+
+<AnVIL2026Demos />


### PR DESCRIPTION
Closes #3697.

This pull request adds a new event page for the AnVIL 2026 August Demos. The page includes event metadata, session details, and renders the appropriate components for display.

Event page creation:

* Added `docs/events/anvil2026-august-demos.mdx` with frontmatter describing the AnVIL 2026 Demos event, including conference name, description, session timing, location, and other metadata.
* Rendered the `EventsHero` and `AnVIL2026Demos` components to display event information and demo session details.