### PR TITLE
feat: add anvil demos september 2026 (#3698)

### DIFF
--- a/docs/events/anvil2026-september-demos.mdx
+++ b/docs/events/anvil2026-september-demos.mdx
@@ -1,0 +1,21 @@
+---
+conference: "AnVIL 2026"
+description: "Learn new ways to use AnVIL and ask questions!"
+eventType: "AnVIL Demos"
+featured: true
+hashtag: "#anvildemos"
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "16 September 2026 10:00 AM",
+      sessionEnd: "16 September 2026 11:00 AM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL Demos"
+---
+
+<EventsHero {...frontmatter} />
+
+<AnVIL2026Demos />


### PR DESCRIPTION
Closes #3698.

This pull request adds a new event page for the "AnVIL Demos" at AnVIL 2026. The page includes event metadata, session details, and renders the event components.

New event page and content:

* Added a new file `docs/events/anvil2026-september-demos.mdx` containing metadata for the "AnVIL Demos" event, including conference name, description, event type, featured status, hashtag, location, session time, timezone, and title.
* Rendered the `<EventsHero />` and `<AnVIL2026Demos />` components to display event information and demo details on the page.