### PR TITLE
feat: add anvil demos october 2026 (#3699)

### DIFF
--- a/docs/events/anvil2026-october-demos.mdx
+++ b/docs/events/anvil2026-october-demos.mdx
@@ -1,0 +1,21 @@
+---
+conference: "AnVIL 2026"
+description: "Learn new ways to use AnVIL and ask questions!"
+eventType: "AnVIL Demos"
+featured: true
+hashtag: "#anvildemos"
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "21 October 2026 10:00 AM",
+      sessionEnd: "21 October 2026 11:00 AM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL Demos"
+---
+
+<EventsHero {...frontmatter} />
+
+<AnVIL2026Demos />


### PR DESCRIPTION
Closes #3699.

This pull request adds a new documentation page for the upcoming "AnVIL Demos" event in October 2026. The page includes event details, featured status, session timing, and renders the corresponding event components.

Event documentation additions:

* Added a new file `docs/events/anvil2026-october-demos.mdx` with metadata for the "AnVIL Demos" event, including conference name, description, event type, hashtag, location, session schedule, timezone, and title.
* Rendered the `<EventsHero />` and `<AnVIL2026Demos />` components to display event information on the page.