### PR TITLE
feat: add anvil demos november 2026 (#3700)

### DIFF
--- a/docs/events/anvil2026-november-demos.mdx
+++ b/docs/events/anvil2026-november-demos.mdx
@@ -1,0 +1,21 @@
+---
+conference: "AnVIL 2026"
+description: "Learn new ways to use AnVIL and ask questions!"
+eventType: "AnVIL Demos"
+featured: true
+hashtag: "#anvildemos"
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "18 November 2026 10:00 AM",
+      sessionEnd: "18 November 2026 11:00 AM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL Demos"
+---
+
+<EventsHero {...frontmatter} />
+
+<AnVIL2026Demos />


### PR DESCRIPTION
Closes #3700.

This pull request adds a new event page for the "AnVIL Demos" session at the AnVIL 2026 conference. The page includes event metadata, session details, and components for displaying event information.

Event page addition:

* Created a new event file `docs/events/anvil2026-november-demos.mdx` with metadata for the AnVIL 2026 Demos, including conference name, description, event type, location, session time, and timezone.
* Added usage of `<EventsHero />` and `<AnVIL2026Demos />` components to render the event details and demos on the page.