### PR TITLE
feat: add anvil demos december 2026 (#3701)

### DIFF
--- a/docs/events/anvil2026-december-demos.mdx
+++ b/docs/events/anvil2026-december-demos.mdx
@@ -1,0 +1,21 @@
+---
+conference: "AnVIL 2026"
+description: "Learn new ways to use AnVIL and ask questions!"
+eventType: "AnVIL Demos"
+featured: true
+hashtag: "#anvildemos"
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "16 December 2026 10:00 AM",
+      sessionEnd: "16 December 2026 11:00 AM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL Demos"
+---
+
+<EventsHero {...frontmatter} />
+
+<AnVIL2026Demos />


### PR DESCRIPTION
Closes #3701.

This pull request adds a new event page for the upcoming "AnVIL Demos" session in December 2026. The page provides event details and renders the appropriate components for the event.

Event page addition:

* Created a new file `docs/events/anvil2026-december-demos.mdx` with metadata and session information for the "AnVIL Demos" event, including conference name, description, date, time, location, and featured status.
* Rendered the `<EventsHero />` and `<AnVIL2026Demos />` components to display the event's details and content.