### PR TITLE
feat: add cshl genome informatics 2025 (#3702)

### DIFF
--- a/docs/events/cshl2025-genome-informatics.mdx
+++ b/docs/events/cshl2025-genome-informatics.mdx
@@ -1,0 +1,41 @@
+---
+conference: "Genome Informatics 2025"
+description: "The AnVIL team will attend CSHL Genome Informatics 2025 to share how the AnVIL platform supports scalable, collaborative genomic data science."
+eventType: "Conference"
+featured: true
+location: "Cold Spring Harbor, NY, USA"
+sessions:
+  [
+    { sessionStart: "5 November 2025" },
+    { sessionStart: "6 November 2025" },
+    { sessionStart: "7 November 2025" },
+    { sessionStart: "8 November 2025" },
+  ]
+timezone: "America/New_York"
+title: "CSHL Genome Informatics 2025"
+---
+
+<EventsHero {...frontmatter} />
+
+The AnVIL team will attend the CSHL Genome Informatics meeting to share about the AnVIL platform with the genomics community. This meeting will draw together researchers focused on genomic data science research, for which AnVIL can be a useful platform to leverage and can offer solutions to some common challenges in the field.
+
+### Background
+
+The next Cold Spring Harbor Laboratory Conference on Genome Informatics will be held at Cold Spring Harbor, New York (this meeting has alternated with the Hinxton meeting started under the joint auspices of CSHL and the Wellcome Trust). The meeting will begin at 7:30 p.m. on Wednesday, November 5th, and finish with lunch on Saturday, November 8, 2025.
+
+Tentative Meeting Topics:
+
+- PanGenomes
+- Genome Assembly and Sequencing Algorithms
+- Algorithmic Evolutionary Biology
+- Single Cell and Spatial Omics
+- Microbial Genomics
+- AI, ML and Integrative Omics
+
+## Event Details
+
+- Conference website: https://meetings.cshl.edu/meetings.aspx?meet=INFO
+- Abstract submission is due on September 8, 2025.
+- How to register: [https://meetings.cshl.edu/meetingsregistrationgeneral.aspx?meet=INFO&year=25](https://meetings.cshl.edu/meetingsregistrationgeneral.aspx?meet=INFO&year=25)
+- Costs: https://meetings.cshl.edu/meetings.aspx?meet=INFO
+- Scholarships supported by the JXTX foundation are available for application through September 15, 2025: https://jxtxfoundation.org/news/2025-6-09-gi


### PR DESCRIPTION
Closes #3702.

<img width="1113" height="1231" alt="image" src="https://github.com/user-attachments/assets/a6dd0500-e66f-459f-bcf9-eec6e03fde00" />

This pull request adds a new event page for the "CSHL Genome Informatics 2025" conference, providing details about the AnVIL team's participation and relevant information for attendees.

New event documentation:

* Added `docs/events/cshl2025-genome-informatics.mdx` to announce AnVIL's attendance at the CSHL Genome Informatics 2025 conference, including event description, location, dates, and session details.
* Included background information, tentative meeting topics, and links for registration, abstract submission, costs, and scholarships to assist prospective attendees.