### PR TITLE
feat:  add cshl biology of genomes 2026 (#3703)

### DIFF
--- a/docs/events/cshl2026-biology-of-genomes.mdx
+++ b/docs/events/cshl2026-biology-of-genomes.mdx
@@ -1,0 +1,44 @@
+---
+conference: "Biology of Genomes 2026"
+description: "The AnVIL team will attend CSHL Biology of Genomes 2026 to share how the AnVIL platform enables scalable, collaborative genomic analysis. This meeting brings together researchers across population and evolutionary genomics, cancer and functional genomics, complex traits and genomic medicine, and emerging methods and technologies."
+eventType: "Conference"
+featured: true
+location: "Cold Spring Harbor, NY, USA"
+sessions:
+  [
+    { sessionStart: "5 May 2026" },
+    { sessionStart: "6 May 2026" },
+    { sessionStart: "7 May 2026" },
+    { sessionStart: "8 May 2026" },
+    { sessionStart: "9 May 2026" },
+  ]
+timezone: "America/New_York"
+title: "CSHL Biology of Genomes 2026"
+---
+
+<EventsHero {...frontmatter} />
+
+The AnVIL team will attend the CSHL Genome Informatics meeting to share about the AnVIL platform with the genomics community. This meeting will draw together researchers focused on genomic data science research, for which AnVIL can be a useful platform to leverage and can offer solutions to some common challenges in the field.
+
+## Background
+
+The 39th annual meeting on Biology of Genomes will begin at 7:30 pm on Tuesday, May 5, 2026, and run through lunch on Saturday, May 9.
+
+The 2026 meeting will address DNA sequence variation and its role in molecular evolution, population genetics, complex diseases, comparative genomics, large-scale studies of gene and protein expression, and genomic approaches to ecological systems. Both technologies and applications will be emphasized. In addition, there will be a special session on the ethical, legal, and social implications (ELSI) of genome research.
+
+Topics:
+
+- Population Genomics
+- Evolutionary & Non-human Genomics
+- Cancer Genomics
+- Computational & Statistical Genomics
+- Complex Traits & Genomic Medicine
+- Functional Genomics
+- Emerging Methods & Technologies
+
+## Event Details
+
+- Conference website: https://meetings.cshl.edu/meetings.aspx?meet=GENOME&year=26
+- Abstract submission is due on February 13, 2026.
+- How to register: https://meetings.cshl.edu/meetingsregistrationgeneral.aspx?meet=GENOME&year=26
+- Costs: https://meetings.cshl.edu/meetings.aspx?meet=GENOME&year=26


### PR DESCRIPTION
Closes #3703.

This pull request adds a new event page for the CSHL Biology of Genomes 2026 conference, providing details about the AnVIL team's participation and relevant information for attendees.

New event documentation:

* Added a new file `docs/events/cshl2026-biology-of-genomes.mdx` with frontmatter and content describing the Biology of Genomes 2026 conference, including dates, location, and sessions.
* Included background information, topics covered, and event details such as registration and abstract submission deadlines, making it easier for users to learn about and participate in the conference.

<img width="1292" height="1230" alt="image" src="https://github.com/user-attachments/assets/7072143f-2c0f-43e3-8c0a-6aeac4e161a8" />
