### PR TITLE
feat: add ashg 2025 to carousel (#3736)

### DIFF
--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -18,6 +18,17 @@ export function buildCarouselCards(): SectionCard[] {
         {
           label: ACTION_LABEL.LEARN_MORE,
           target: ANCHOR_TARGET.SELF,
+          url: "/events/ashg2025-american-society-of-human-genetics",
+        },
+      ],
+      text: "The ASHG 2025 Annual Meeting will be held in Boston from October 14-18. The meeting will feature a wide range of scientific sessions, including plenary lectures, symposia, workshops, and poster presentations.",
+      title: "American Society of Human Genetics Annual Meeting 2025",
+    },
+    {
+      links: [
+        {
+          label: ACTION_LABEL.LEARN_MORE,
+          target: ANCHOR_TARGET.SELF,
           url: "/news/2025/08/25/all-of-us-anvil-imputation-service",
         },
       ],


### PR DESCRIPTION
Closes #3736.

<img width="1873" height="812" alt="image" src="https://github.com/user-attachments/assets/020d445d-af2f-4112-8a39-83ed724b49e5" />

This pull request adds a new carousel card to the homepage section, highlighting the upcoming American Society of Human Genetics Annual Meeting in 2025.

Homepage carousel update:

* Added a new card to the carousel in `buildCarouselCards` with details and a link for the ASHG 2025 Annual Meeting in Boston.