### PR TITLE
content: add gregor consortium v 4 data release on anvil news (#3745)

### DIFF
--- a/docs/news/2025/11/04/gregor-consortium-data-release.mdx
+++ b/docs/news/2025/11/04/gregor-consortium-data-release.mdx
@@ -9,7 +9,7 @@ title: "Data Release - GREGoR Consortium"
 
 The fourth data release from the [GREGoR Consortium](https://gregorconsortium.org) (Genomics Research to Elucidate the Genetics of Rare diseases) is now available on AnVIL for controlled access by the broader scientific community. Additionally, the GREGoR Consortium has developed a publicly available open-access [variant browser](https://variants.gregorconsortium.org) that enables searches for variants of interest across the Consortium joint, short-read whole genome callset.
 
-Access requests for these controlled datasets are available through dbGaP under accession [phs003047](http://google.com/url?q=https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id%3Dphs003047.v3.p2%23attribution-section&sa=D&source=docs&ust=1761841465946788&usg=AOvVaw1vvLHSCdb3mxlJ6M-hOKj9) and the data is available at https://explore.anvilproject.org/datasets or https://duos.org/datalibrary/anvil.
+Access requests for these controlled datasets are available through dbGaP under accession [phs003047](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs003047.v3.p2#attribution-section) and the data is available at https://explore.anvilproject.org/datasets or https://duos.org/datalibrary/anvil.
 
 The GREGoR Consortium has assembled a dataset of broad utility. All participants are broadly consented for General Research Use or Health, Medical, or Biomedical research. The Consortium data aligns with [the GREGoR Data Model](https://github.com/UW-GAC/gregor_data_models), designed to provide context and information to support analysis and secondary use of the data. Additional documentation, including how to apply for access, is available on the GREGoR Consortium’s [Data webpage](https://gregorconsortium.org/data).
 
@@ -30,4 +30,4 @@ This fourth data release contains data from 10,683 participants in 4,366 familie
 
 ## Acknowledgements and attribution
 
-The GREGoR Acknowledgements and attribution statement are available at the [dbGaP study page](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs003047.v3.p2#attribution-section). You can learn more about GREGoR at https://gregorconsortium.org/ 
+The GREGoR Acknowledgements and attribution statement are available at the [dbGaP study page](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs003047.v3.p2#attribution-section). You can learn more about GREGoR at https://gregorconsortium.org/.


### PR DESCRIPTION
Closes #3745.

This pull request adds a new news post announcing the fourth data release from the GREGoR Consortium, making new genomic datasets available for controlled access and providing details about the release. The update informs users about the scope of the data, access instructions, and relevant resources.

New data release announcement:

* Added a news post (`docs/news/2025/11/04/gregor-consortium-data-release.mdx`) detailing the fourth GREGoR Consortium data release, including participant and dataset statistics, access instructions, and links to resources such as the variant browser and data documentation.

<img width="1172" height="931" alt="image" src="https://github.com/user-attachments/assets/3fc9a9cf-face-49af-8fd8-025b630f5ebb" />
