### PR TITLE
content: add cmg data release on the anvil platform news (#3747)

### DIFF
--- a/docs/news/2025/11/04/cmg-data-release.mdx
+++ b/docs/news/2025/11/04/cmg-data-release.mdx
@@ -1,0 +1,24 @@
+---
+date: "2025-11-04"
+description: "New datasets from the Broad's Center for Mendelian Genomics (CMG) are now available on AnVIL."
+featured: true
+title: "Center for Mendelian Genomics Data Release on the AnVIL Platform"
+---
+
+<NewsHero {...frontmatter} />
+
+A new release from the Broad’s Center for Mendelian Genomics (CMG) is now available in AnVIL for the broader scientific community (phs001272.v3.p1).
+
+The Broad Center for Mendelian Genomics is a research study using next-generation sequencing and computational approaches to identify novel genes for Mendelian diseases. By discovering genes that cause Mendelian conditions, we will expand our understanding of their biology to facilitate diagnosis and new treatments. The following datasets are now available in AnVIL:
+
+| Dataset | Number of Samples | Consent Code |
+| :-- | :-- | :-- |
+| AnVIL_CMG_Broad_Muscle_Beggs_WES | 275 | DS-Neurology, MDS |
+| AnVIL_CMG_Broad_LymphDisease_Fajgenbaum_WES | 26 | GRU |
+| AnVIL_CMG_Broad_Blood_Fleming_WES | 361 | DS (Bone Failure Disorders, MDS) |
+| AnVIL_CMG_Broad_Blood_Gazda_WES | 83 | DS (Bone Failure Disorders, MDS) |
+| AnVIL_CMG_Broad_Genitourinary_Hirschhorn_WES | 109 | HMB |
+| AnVIL_CMG_Broad_Muscle_Kang_WES | 67 | DS - Neurology, MDS |
+| AnVIL_CMG_Broad_Orphan_VCGS-White_WES | 971 | HMB, NPU, MDS |
+
+Access requests for these controlled datasets are available through dbGaP under accession [phs001272](https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001272.v2.p1) and the data is available at https://explore.anvilproject.org/datasets or https://duos.org/datalibrary/anvil.


### PR DESCRIPTION
Closes #3747.

This pull request adds a new news article announcing the release of datasets from the Broad's Center for Mendelian Genomics (CMG) on the AnVIL platform. The article provides an overview of the research, details about the available datasets, and instructions for accessing the data.

New documentation and announcement:

* Added `docs/news/2025/11/04/cmg-data-release.mdx` to announce the release of CMG datasets on AnVIL, including dataset descriptions, sample counts, consent codes, and access instructions.

<img width="1343" height="1205" alt="image" src="https://github.com/user-attachments/assets/1329a9f3-ce41-4368-9291-c80737d4e4dc" />
