### PR TITLE
content: update learn section card descriptions (#3761)

### DIFF
--- a/views/LearnView/constants.ts
+++ b/views/LearnView/constants.ts
@@ -22,8 +22,7 @@ export const CARDS: ComponentProps<typeof CTACard>[] = [
       src: "/consortia/learn/anvil.webp",
       width: 48,
     },
-    secondaryText:
-      "The following is a guided walk-through of the AnVIL documentation",
+    secondaryText: "Learn about the AnVIL platform",
     title: "What is AnVIL?",
   },
   {
@@ -81,20 +80,19 @@ export const CARDS: ComponentProps<typeof CTACard>[] = [
   {
     StartIcon: SupportIcon,
     cardUrl: "https://help.anvilproject.org",
-    secondaryText: "Check out the AnVIL Community for support",
+    secondaryText: "Check out the AnVIL Support Forum",
     title: "Get Help",
   },
   {
     StartIcon: LiveHelpIcon,
     cardUrl: ROUTES.FAQ,
-    secondaryText:
-      "What is AnVIL? What is an AnVIL Workspace? What is Terra and how does it relate to AnVIL? Check out our FAQs",
+    secondaryText: "Get answers to common questions",
     title: "FAQs",
   },
   {
     StartIcon: TerminalIcon,
     cardUrl: "https://help.anvilproject.org/c/demos/5",
-    secondaryText: "Short demos followed by live Q&A",
+    secondaryText: "Attend or review researcher demos",
     title: "AnVIL Demos",
   },
 ];


### PR DESCRIPTION
Closes #3761.

This pull request updates the text for several cards in the `CARDS` array in `views/LearnView/constants.ts` to improve clarity and user experience. The changes focus on making the secondary text more concise and descriptive for each card.

Content and messaging improvements:

* Updated the secondary text for the "What is AnVIL?" card to "Learn about the AnVIL platform" for clearer messaging.
* Changed the "Get Help" card's secondary text to "Check out the AnVIL Support Forum" to better reflect the destination.
* Simplified the "FAQs" card's secondary text to "Get answers to common questions" for brevity and clarity.
* Revised the "AnVIL Demos" card's secondary text to "Attend or review researcher demos" to better describe the content.

<img width="2322" height="1168" alt="image" src="https://github.com/user-attachments/assets/80d03e98-91e5-4498-aaf6-869fcb16806a" />
