### PR TITLE
feat: swap demo overlines and titles (#3770)

### DIFF
--- a/docs/events/anvil2025-december-demos.mdx
+++ b/docs/events/anvil2025-december-demos.mdx
@@ -1,7 +1,7 @@
 ---
 conference: "AnVIL 2025"
 description: "Learn new ways to use AnVIL and ask questions!"
-eventType: "AnVIL Demos: AnVIL Data Explorer: Building and Exporting Dataset Cohorts"
+eventType: "AnVIL Demos"
 featured: true
 hashtag: "#anvildemos"
 location: "Virtual"
@@ -13,7 +13,7 @@ sessions:
     },
   ]
 timezone: "America/New_York"
-title: "AnVIL Demos"
+title: "AnVIL Data Explorer: Building and Exporting Dataset Cohorts"
 ---
 
 <EventsHero {...frontmatter} />

--- a/docs/events/anvil2025-november-demos.mdx
+++ b/docs/events/anvil2025-november-demos.mdx
@@ -1,7 +1,7 @@
 ---
 conference: "AnVIL 2025"
 description: "Learn new ways to use AnVIL and ask questions!"
-eventType: "AnVIL Demos: AnVIL meets the new security requirements under the Genomic Data Sharing Policy"
+eventType: "AnVIL Demos"
 featured: true
 hashtag: "#anvildemos"
 location: "Virtual"
@@ -13,7 +13,7 @@ sessions:
     },
   ]
 timezone: "America/New_York"
-title: "AnVIL Demos"
+title: "AnVIL meets the new security requirements under the Genomic Data Sharing Policy"
 ---
 
 <EventsHero {...frontmatter} />

--- a/docs/events/anvil2026-february-demos.mdx
+++ b/docs/events/anvil2026-february-demos.mdx
@@ -1,7 +1,7 @@
 ---
 conference: "AnVIL 2026"
 description: "Learn new ways to use AnVIL and ask questions!"
-eventType: "AnVIL Demos: Genomic analysis using seqr on AnVIL"
+eventType: "AnVIL Demos"
 featured: true
 hashtag: "#anvildemos"
 location: "Virtual"
@@ -13,7 +13,7 @@ sessions:
     },
   ]
 timezone: "America/New_York"
-title: "AnVIL Demos"
+title: "Genomic analysis using seqr on AnVIL"
 ---
 
 <EventsHero {...frontmatter} />

--- a/docs/events/anvil2026-january-demos.mdx
+++ b/docs/events/anvil2026-january-demos.mdx
@@ -1,7 +1,7 @@
 ---
 conference: "AnVIL 2026"
 description: "Learn new ways to use AnVIL and ask questions!"
-eventType: "AnVIL Demos: Supporting Self-Service Data Ingestion for AnVIL"
+eventType: "AnVIL Demos"
 featured: true
 hashtag: "#anvildemos"
 location: "Virtual"
@@ -13,7 +13,7 @@ sessions:
     },
   ]
 timezone: "America/New_York"
-title: "AnVIL Demos"
+title: "Supporting Self-Service Data Ingestion for AnVIL"
 ---
 
 <EventsHero {...frontmatter} />


### PR DESCRIPTION
Closes #3770.

This pull request updates the event metadata for several upcoming AnVIL Demos sessions to improve consistency and clarity. The main changes involve standardizing the `eventType` field across all demo event files and moving the specific session topic from the `eventType` field to the `title` field.

**Event Metadata Standardization:**

* Updated the `eventType` field in `anvil2025-december-demos.mdx`, `anvil2025-november-demos.mdx`, `anvil2026-january-demos.mdx`, and `anvil2026-february-demos.mdx` to use the generic value `"AnVIL Demos"` instead of including the session-specific topic. [[1]](diffhunk://#diff-03de8848b56875bbc36d1c70451ce3c00dd072a28179246a4612a44d07d219f9L4-R4) [[2]](diffhunk://#diff-9e6748723037f362c9b9e99973f816d08ae1be25f51fdc4ab91cbf9655d67d33L4-R4) [[3]](diffhunk://#diff-980248c7d62a3302b5678cfe4fa8b572b6f583cd39ac3a0ad54f5956612b4eefL4-R4) [[4]](diffhunk://#diff-16db8bd2eb26b5118e142f5acaf9dee5f414e1aa5fdcd972473102d6d245cd3aL4-R4)

**Session Title Clarification:**

* Moved the session-specific topic from the `eventType` field to the `title` field in each event file, ensuring the `title` now clearly reflects the unique focus of each session. [[1]](diffhunk://#diff-03de8848b56875bbc36d1c70451ce3c00dd072a28179246a4612a44d07d219f9L16-R16) [[2]](diffhunk://#diff-9e6748723037f362c9b9e99973f816d08ae1be25f51fdc4ab91cbf9655d67d33L16-R16) [[3]](diffhunk://#diff-980248c7d62a3302b5678cfe4fa8b572b6f583cd39ac3a0ad54f5956612b4eefL16-R16) [[4]](diffhunk://#diff-16db8bd2eb26b5118e142f5acaf9dee5f414e1aa5fdcd972473102d6d245cd3aL16-R16)

<img width="1613" height="1245" alt="image" src="https://github.com/user-attachments/assets/7b15a16c-8aae-423e-a12b-27c9ce9d352f" />
