### PR TITLE
fix: moved releases to /releases #3825

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -169,7 +169,7 @@ Commits must follow the conventional commits format enforced by commitlint:
 ### Navigation
 
 - Navigation is configured in `site-config/anvil-portal/dev/navigation/` and shared across all environments
-- Each major section (learn, news, faq, team, overview, champions, events, help, data-releases, guides, privacy, consortia) has its own navigation configuration file
+- Each major section (learn, news, faq, team, overview, champions, events, help, releases, guides, privacy, consortia) has its own navigation configuration file
 
 ### Styling
 

--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -17,7 +17,7 @@ export function buildCarouselCards(): SectionCard[] {
       links: [
         {
           label: ACTION_LABEL.LEARN_MORE,
-          url: "/data-releases/2025/11/release-notes",
+          url: "/releases/2025/11/release-notes",
         },
       ],
       text: "Explore newly released and updated studies on the AnVIL platform - find datasets in the Data Explorer and Data Library.",

--- a/docs/common/entities.ts
+++ b/docs/common/entities.ts
@@ -14,7 +14,6 @@ export interface NavigationEntry {
 export enum NavigationKey {
   ANVIL_CHAMPIONS = "anvil-champions",
   CONSORTIA = "consortia",
-  DATA_RELEASES = "data-releases",
   EVENTS = "events",
   FAQ = "faq",
   GUIDES = "guides",
@@ -23,6 +22,7 @@ export enum NavigationKey {
   NEWS = "news",
   OVERVIEW = "overview",
   PRIVACY = "privacy",
+  RELEASES = "releases",
   TEAM = "team",
 }
 

--- a/docs/releases/2025/08/release-notes.mdx
+++ b/docs/releases/2025/08/release-notes.mdx
@@ -2,7 +2,7 @@
 breadcrumbs:
   - path: "/"
     text: "Home"
-  - path: "/data-releases"
+  - path: "/releases"
     text: "Releases"
   - path: ""
     text: "August 2025 Release"

--- a/docs/releases/2025/11/release-notes.mdx
+++ b/docs/releases/2025/11/release-notes.mdx
@@ -2,7 +2,7 @@
 breadcrumbs:
   - path: "/"
     text: "Home"
-  - path: "/data-releases"
+  - path: "/releases"
     text: "Releases"
   - path: ""
     text: "November 2025 Release"

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -27,7 +27,7 @@ import { rehypeSlug } from "../plugins/rehypeSlug";
 import { remarkHeadings } from "../plugins/remarkHeadings";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
 
-const CONFLICTING_STATIC_PATHS = ["events", "learn", "news", "data-releases"];
+const CONFLICTING_STATIC_PATHS = ["events", "learn", "news", "releases"];
 
 interface DocPageProps {
   hero: NodeHero | null;

--- a/pages/releases/[year]/[month]/[slug].tsx
+++ b/pages/releases/[year]/[month]/[slug].tsx
@@ -16,7 +16,7 @@ import { StaticProps } from "../../../../content/entities";
 import { ContentOverviewView } from "../../../../views/ContentOverviewView/contentOverviewView";
 
 const DOCS_DIR = "docs";
-const DATA_RELEASES_DIR = "data-releases";
+const RELEASES_DIR = "releases";
 
 interface PageUrlParams extends ParsedUrlQuery {
   month: string;
@@ -54,7 +54,7 @@ export const getStaticProps: GetStaticProps = async (
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const paths = mapParams(
-    generatePaths(resolveRelativeDirs([DOCS_DIR, DATA_RELEASES_DIR]))
+    generatePaths(resolveRelativeDirs([DOCS_DIR, RELEASES_DIR]))
   );
   return { fallback: false, paths };
 };
@@ -74,7 +74,7 @@ Page.Main = StyledMain;
  */
 function getSlug(params: PageUrlParams): string[] {
   const { month, slug, year } = params;
-  return ["data-releases", year, month, slug];
+  return ["releases", year, month, slug];
 }
 
 /**

--- a/pages/releases/index.tsx
+++ b/pages/releases/index.tsx
@@ -12,7 +12,7 @@ import slugify from "slugify";
 import { getMatter } from "../../content/utils";
 
 const DOCS_DIR = "docs";
-const DATA_RELEASES_DIR = "data-releases";
+const RELEASES_DIR = "releases";
 
 export interface PageProps
   extends Omit<StaticProps, "layoutStyle" | "mdxSource"> {
@@ -34,7 +34,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async () => {
       outline,
       pageTitle: "Releases",
       releases,
-      slug: [DATA_RELEASES_DIR],
+      slug: [RELEASES_DIR],
     },
   };
 };
@@ -87,7 +87,7 @@ function buildReleases(
  * @returns date path.
  */
 function getDatePath(slug: string[]): string {
-  return `/${DATA_RELEASES_DIR}/${slug.join("/")}`;
+  return `/${RELEASES_DIR}/${slug.join("/")}`;
 }
 
 /**
@@ -108,7 +108,7 @@ function getDatePathMap(slugs: string[][]): Map<Date, string> {
 function getDataReleaseSlugs(): string[][] {
   return [
     ...mapSlugByFilePaths(
-      resolveRelativeDirs([DOCS_DIR, DATA_RELEASES_DIR])
+      resolveRelativeDirs([DOCS_DIR, RELEASES_DIR])
     ).values(),
   ];
 }

--- a/routes/constants.ts
+++ b/routes/constants.ts
@@ -1,7 +1,6 @@
 export const ROUTES = {
   ANVIL_CHAMPIONS: "/anvil-champions",
   CONSORTIA: "/consortia",
-  DATA_RELEASES: "/data-releases",
   EVENTS: "/events",
   FAQ: "/faq",
   GUIDES: "/guides",
@@ -10,6 +9,7 @@ export const ROUTES = {
   NEWS: "/news",
   OVERVIEW: "/overview",
   PRIVACY: "/privacy",
+  RELEASES: "/releases",
   SEARCH: "/search",
   TEAM: "/team",
 };

--- a/site-config/anvil-portal/dev/config.ts
+++ b/site-config/anvil-portal/dev/config.ts
@@ -104,7 +104,7 @@ export function makeConfig(
                 {
                   description: "Summary of data releases and upcoming changes.",
                   label: "Data Releases",
-                  url: ROUTES.DATA_RELEASES,
+                  url: ROUTES.RELEASES,
                 },
               ],
               url: "",

--- a/site-config/anvil-portal/dev/navigation/navigation.ts
+++ b/site-config/anvil-portal/dev/navigation/navigation.ts
@@ -1,7 +1,7 @@
 import { NavigationConfig } from "../../../../docs/common/entities";
 import { ANVIL_CHAMPIONS } from "./champions";
 import { CONSORTIA } from "./consortia";
-import { DATA_RELEASES } from "./data-releases";
+import { RELEASES } from "./releases";
 import { EVENTS } from "./events";
 import { FAQ } from "./faq";
 import { GUIDES } from "./guides";
@@ -16,7 +16,6 @@ import { TEAM } from "./team";
 export const navigation: NavigationConfig = {
   ["anvil-champions"]: ANVIL_CHAMPIONS,
   consortia: CONSORTIA,
-  ["data-releases"]: DATA_RELEASES,
   events: EVENTS,
   faq: FAQ,
   guides: GUIDES,
@@ -25,5 +24,6 @@ export const navigation: NavigationConfig = {
   news: NEWS,
   overview: OVERVIEW,
   privacy: PRIVACY,
+  releases: RELEASES,
   team: TEAM,
 };

--- a/site-config/anvil-portal/dev/navigation/releases.ts
+++ b/site-config/anvil-portal/dev/navigation/releases.ts
@@ -4,17 +4,17 @@ import {
 } from "../../../../docs/common/entities";
 
 const NODE_KEYS: Record<string, NavigationNode["key"]> = {
-  DATA_RELEASES: "data-releases",
+  RELEASES: "releases",
 };
 const PATH_SEGMENTS = {
-  DATA_RELEASES: "data-releases",
+  RELEASES: "releases",
 };
 
-export const DATA_RELEASES: NavigationEntry = {
+export const RELEASES: NavigationEntry = {
   nodes: [
     {
-      key: NODE_KEYS.DATA_RELEASES,
-      slugs: [PATH_SEGMENTS.DATA_RELEASES],
+      key: NODE_KEYS.RELEASES,
+      slugs: [PATH_SEGMENTS.RELEASES],
     },
   ],
 };

--- a/views/ReleasesView/releasesView.tsx
+++ b/views/ReleasesView/releasesView.tsx
@@ -2,7 +2,7 @@ import { Fragment } from "react";
 import { StyledCard } from "./releasesView.styles";
 import { SectionHero } from "../../components/Layout/components/Section/components/SectionHero/sectionHero";
 import { SectionContent } from "../../components/Layout/components/Section/components/SectionContent/sectionContent";
-import { PageProps } from "../../pages/data-releases/index";
+import { PageProps } from "../../pages/releases/index";
 import { Stack, Typography } from "@mui/material";
 import { CardActionArea } from "@databiosphere/findable-ui/lib/components/common/Card/components/CardActionArea/cardActionArea";
 import { CardSecondaryText } from "@databiosphere/findable-ui/lib/components/common/Card/components/CardSecondaryText/cardSecondaryText";


### PR DESCRIPTION
#### Ticket

Closes #3825.


#### Changes

This pull request standardizes the naming of the "data releases" section across the codebase, renaming it to "releases" for consistency and clarity. The changes update enums, constants, navigation configuration, routes, file paths, and references throughout the project to use the new naming convention.

**Navigation and Routing Updates:**

* Updated the navigation configuration and route constants to replace `data-releases` with `releases` in all relevant files, including enums (`NavigationKey`), constants (`ROUTES`), and navigation config files. [[1]](diffhunk://#diff-53dca0694af02710fbe401ddc7f6abbca59f86e444b354890dc1227d82e8c7a0L17) [[2]](diffhunk://#diff-53dca0694af02710fbe401ddc7f6abbca59f86e444b354890dc1227d82e8c7a0R25) [[3]](diffhunk://#diff-7ebd9e98055eaac29228f42c33478b95f17575f8f3985c398ab07656c2f3cf3fL4) [[4]](diffhunk://#diff-7ebd9e98055eaac29228f42c33478b95f17575f8f3985c398ab07656c2f3cf3fR12) [[5]](diffhunk://#diff-a637d22402a47eaa13c4d03922a9b4fc0ef9bdc0eb8414bb24884327e1ed41deL4-R4) [[6]](diffhunk://#diff-a637d22402a47eaa13c4d03922a9b4fc0ef9bdc0eb8414bb24884327e1ed41deL19) [[7]](diffhunk://#diff-a637d22402a47eaa13c4d03922a9b4fc0ef9bdc0eb8414bb24884327e1ed41deR27) [[8]](diffhunk://#diff-4903ae0df7d1bd5ab6d0352d01ff79bd61105050be2bbf3ce4d38ae791799a77L7-R17)
* Modified navigation instructions and documentation to reflect the new section name.

**File and Directory Renaming:**

* Renamed all files and directories from `data-releases` to `releases`, including MDX release note files and Next.js page files. Updated imports and references accordingly. [[1]](diffhunk://#diff-45b9e6ea6972eabe0f6f80f1b6a77f23ef87737f0a34fad0844491afc5b1040eL5-R5) [[2]](diffhunk://#diff-fb8420937d8c96423d13bbab1b72c32aaf14efba87d44d4eeb3958214e1fbfe9L5-R5) [pages/releases/[year]/[month]/[slug].tsxL19-R19](diffhunk://#diff-5aa7fedcfaea34f9498720c344e1b98df7004d175e0f3e17f1128c375a006100L19-R19), [pages/releases/[year]/[month]/[slug].tsxL57-R57](diffhunk://#diff-5aa7fedcfaea34f9498720c344e1b98df7004d175e0f3e17f1128c375a006100L57-R57), [pages/releases/[year]/[month]/[slug].tsxL77-R77](diffhunk://#diff-5aa7fedcfaea34f9498720c344e1b98df7004d175e0f3e17f1128c375a006100L77-R77), [[3]](diffhunk://#diff-42239eb8d7876b3267f396e7f1a7d957bcf63b216884096fbf02aa145a71e793L15-R15) [[4]](diffhunk://#diff-42239eb8d7876b3267f396e7f1a7d957bcf63b216884096fbf02aa145a71e793L37-R37) [[5]](diffhunk://#diff-42239eb8d7876b3267f396e7f1a7d957bcf63b216884096fbf02aa145a71e793L90-R90) [[6]](diffhunk://#diff-42239eb8d7876b3267f396e7f1a7d957bcf63b216884096fbf02aa145a71e793L111-R111) [[7]](diffhunk://#diff-4903ae0df7d1bd5ab6d0352d01ff79bd61105050be2bbf3ce4d38ae791799a77L7-R17) [[8]](diffhunk://#diff-144ed1ca5c7dc13ed0703f5d8611992e76e3af3008d08f040da0c34d388b8dd0L5-R5)

**Component and Utility Updates:**

* Updated utility functions, component props, and internal logic to reference `releases` instead of `data-releases`, ensuring all links and paths are correct throughout the site. [[1]](diffhunk://#diff-e6b819cab4350f55c7b0140e6689f422590acb49b2efe3ee26de2e3f42ffef36L20-R20) [[2]](diffhunk://#diff-a85492a7f6237f114a3882bc9749d3001dd978af368ee555b05647ad90e759e2L107-R107) [pages/[...slug].tsxL30-R30](diffhunk://#diff-5e5186614071390e5a8824f814c2a49cd4083adc99ada4220e546a421676ca2aL30-R30))

**Static Path and Slug Handling:**

* Changed static path generation and slug handling in Next.js pages to use the new `releases` directory, ensuring correct routing and page generation. ([pages/releases/[year]/[month]/[slug].tsxL57-R57](diffhunk://#diff-5aa7fedcfaea34f9498720c344e1b98df7004d175e0f3e17f1128c375a006100L57-R57), [pages/releases/[year]/[month]/[slug].tsxL77-R77](diffhunk://#diff-5aa7fedcfaea34f9498720c344e1b98df7004d175e0f3e17f1128c375a006100L77-R77), [[1]](diffhunk://#diff-42239eb8d7876b3267f396e7f1a7d957bcf63b216884096fbf02aa145a71e793L90-R90) [[2]](diffhunk://#diff-42239eb8d7876b3267f396e7f1a7d957bcf63b216884096fbf02aa145a71e793L111-R111)

**Breadcrumb and UI Text Updates:**

* Updated breadcrumbs and UI text in release note pages to reflect the new section name, improving clarity for end users. [[1]](diffhunk://#diff-45b9e6ea6972eabe0f6f80f1b6a77f23ef87737f0a34fad0844491afc5b1040eL5-R5) [[2]](diffhunk://#diff-fb8420937d8c96423d13bbab1b72c32aaf14efba87d44d4eeb3958214e1fbfe9L5-R5)

Let me know if you want to review any specific part of the migration or need help understanding the impact on a particular feature!