### PR TITLE
fix: fix release notes layout (#3837)

### DIFF
--- a/views/ContentOverviewView/contentOverviewView.tsx
+++ b/views/ContentOverviewView/contentOverviewView.tsx
@@ -41,9 +41,9 @@ function renderContentEnd(props: StaticProps): JSX.Element | null {
 }
 
 /**
- * Renders page outline component
+ * Renders page outline component.
  * @param props - Static Props.
- * @returns outline component
+ * @returns outline component.
  */
 function renderOutline(props: StaticProps): JSX.Element | null {
   if (!props.frontmatter.enableOutline) return null;


### PR DESCRIPTION
Closes #3837.

This pull request refactors the way the outline is rendered in the `ContentOverviewView` component. The main change is that the `renderOutline` function now receives the entire `props` object instead of just the outline data, allowing it to access additional properties such as `frontmatter`. This enables conditional rendering of the outline based on the `enableOutline` flag in the frontmatter, and simplifies the prop passing to the `Outline` component.

**Refactor and prop handling improvements:**

* The `renderOutline` function now takes the full `StaticProps` object and checks the `frontmatter.enableOutline` flag before rendering the outline, improving conditional rendering and making the code more robust.
* The main `ContentOverviewView` component is updated to pass the entire `props` object to `renderOutline` and to pass the `slug` prop directly to the `Outline` component, simplifying prop management. [[1]](diffhunk://#diff-8cd04b21061f992de59f77230a51935c7983cb2e6042b2e3f966ebf230d64a8aL15-R14) [[2]](diffhunk://#diff-8cd04b21061f992de59f77230a51935c7983cb2e6042b2e3f966ebf230d64a8aL27-R27)

**Code cleanup:**

* Unused imports, such as `OutlineItem`, are removed from the file for clarity.

<img width="1728" height="930" alt="image" src="https://github.com/user-attachments/assets/0969d008-e59e-4fab-bf29-9517553caebc" />
