### PR TITLE
feat: update datasets menu item (#3835)

### DIFF
--- a/site-config/anvil-portal/dev/config.ts
+++ b/site-config/anvil-portal/dev/config.ts
@@ -93,10 +93,10 @@ export function makeConfig(
                 },
                 {
                   description:
-                    "Newly released studies not available in the AnVIL Data Explorer are accessible in DUOS.",
+                    "Study-level export and newly released studies not available in the Explorer.",
                   label: C.LabelIconMenuItem({
                     iconFontSize: "small",
-                    label: "Early Access Studies",
+                    label: "Data Library",
                   }),
                   target: ANCHOR_TARGET.BLANK,
                   url: "https://duos.org/datalibrary/AnVIL",


### PR DESCRIPTION
Closes #3835.

This pull request updates the labeling and description for a menu item in the AnVIL Portal configuration to better reflect its current functionality.

Menu item updates:

* Changed the menu item label from "Early Access Studies" to "Data Library" and updated its description to "Study-level export and newly released studies not available in the Explorer." (`site-config/anvil-portal/dev/config.ts`)

<img width="1728" height="896" alt="image" src="https://github.com/user-attachments/assets/75dd8875-8273-4f48-b5b8-fae7b16f12d0" />
