### PR TITLE
content: add acc2026 event (#3838)

### DIFF
--- a/docs/events/anvil2026-community-conference.mdx
+++ b/docs/events/anvil2026-community-conference.mdx
@@ -21,7 +21,7 @@ sessions:
     }
   ]
 timezone: "America/New_York"
-title: " AnVIL Community Conference 2026"
+title: "AnVIL Community Conference 2026"
 ---
 
 <EventsHero {...frontmatter} />


### PR DESCRIPTION
Closes #3838.

This pull request adds a new event page for the AnVIL Community Conference 2026 to the documentation. The page includes key event details, session times, and community information for attendees.

New event documentation:

* Created `docs/events/anvil2026-community-conference.mdx` to announce and provide details for the AnVIL Community Conference 2026, including conference metadata, session schedule, location, and links for mailing list and registration information.

<img width="1724" height="928" alt="image" src="https://github.com/user-attachments/assets/011b30d6-5914-4cd8-aaf8-83282ae1021f" />
