### PR TITLE
content: fixed guide link in README #3878

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AnVIL is an Analysis, Visualization, and Informatics Lab-space for democratizing
 
 ## Content Contributor Guide
 
-Information about creating/modifying the site content can be found here: [https://anvilproject.org/content-guide](https://anvilproject.org/content-guide)
+Information about creating/modifying the site content can be found here: [https://anvilproject.org/guides](https://anvilproject.org/guides)
 
 ## Setting Up a Developer Workspace
 


### PR DESCRIPTION
I was trying to use the "Content Contributor Guide" and saw the previous link (https://anvilproject.org/content-guide) is not active. I am proposing updating to the link for the "AnVIL Content Guide" (https://anvilproject.org/guides)