### PR TITLE
chore: update findable-ui to latest (#3882)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "the-anvil",
       "version": "2.27.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^48",
+        "@databiosphere/findable-ui": "^49.0.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3.0.1",
@@ -1057,9 +1057,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "48.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-48.1.0.tgz",
-      "integrity": "sha512-J1Qt37wUODYhOB0uZELaRsfFEjlCH2zA3hASU3YYFMNGCg1vnn+8TWEbzXENiORku5sXs8cUoNdJYjacrS0RLQ==",
+      "version": "49.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-49.0.0.tgz",
+      "integrity": "sha512-Vo1fmniyziutpm6DcbxWP4i/Ppe+kTSoubvMy24LGdNqB6pEjIdQ0Lka+hlpqEnh/Q9TeBWyEMu5OMDI6rEo7g==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fetch-citations": "node scripts/fetch-citations.mjs --build-publications"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^48",
+    "@databiosphere/findable-ui": "^49.0.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3.0.1",

--- a/site-config/anvil-portal/publications/entityConfig.ts
+++ b/site-config/anvil-portal/publications/entityConfig.ts
@@ -31,6 +31,7 @@ import {
   PUBLICATION_CATEGORY_KEY,
   PUBLICATION_CATEGORY_LABEL,
 } from "./category";
+import { CHART_SORT } from "@databiosphere/findable-ui/lib/common/chart/sort/types";
 
 /**
  * Publications entity category group config for faceted filtering.
@@ -40,7 +41,7 @@ const categoryGroupConfig: CategoryGroupConfig = {
     {
       categoryConfigs: [
         {
-          enableChartView: false,
+          chart: { enable: false },
           key: PUBLICATION_CATEGORY_KEY.TITLE,
           label: PUBLICATION_CATEGORY_LABEL.TITLE,
         },
@@ -49,7 +50,7 @@ const categoryGroupConfig: CategoryGroupConfig = {
           label: PUBLICATION_CATEGORY_LABEL.JOURNAL,
         },
         {
-          enableChartView: false,
+          chart: { enable: false },
           key: PUBLICATION_CATEGORY_KEY.PMID,
           label: PUBLICATION_CATEGORY_LABEL.PMID,
         },
@@ -58,6 +59,7 @@ const categoryGroupConfig: CategoryGroupConfig = {
           label: PUBLICATION_CATEGORY_LABEL.AUTHORS,
         },
         {
+          chart: { enable: true, sortBy: CHART_SORT.ALPHA },
           key: PUBLICATION_CATEGORY_KEY.YEAR,
           label: PUBLICATION_CATEGORY_LABEL.YEAR,
         },


### PR DESCRIPTION
Closes #3882.

This pull request updates the `@databiosphere/findable-ui` dependency and refactors chart configuration for publication categories in the AnVIL portal. The most significant changes include switching to the new chart config structure and enabling alphabetical sorting for the year chart.

Dependency update:

* Upgraded the `@databiosphere/findable-ui` dependency from version 48 to 49.0.0 in `package.json`, ensuring compatibility with the latest features and bug fixes.

Chart configuration refactor:

* Refactored chart configuration in `site-config/anvil-portal/publications/entityConfig.ts` to use the new `chart` object structure instead of the deprecated `enableChartView` property for publication categories like TITLE and PMID. [[1]](diffhunk://#diff-6d0d56efff97d78b6f9647cd2c4e9ae2b9c7e82714ffdd4728853e8f60a476ccL43-R44) [[2]](diffhunk://#diff-6d0d56efff97d78b6f9647cd2c4e9ae2b9c7e82714ffdd4728853e8f60a476ccL52-R53)
* Enabled the chart view for the YEAR category and specified alphabetical sorting using `CHART_SORT.ALPHA`.
* Added import for `CHART_SORT` from `@databiosphere/findable-ui/lib/common/chart/sort/types` to support the new chart sorting configuration.

<img width="2362" height="1210" alt="image" src="https://github.com/user-attachments/assets/2ee4deba-ad65-4b3b-be55-4c5d0310e87f" />
