### PR TITLE
content: add DepMap data release news article

### DIFF
--- a/docs/news/2026/03/03/depmap-data-release.mdx
+++ b/docs/news/2026/03/03/depmap-data-release.mdx
@@ -1,8 +1,8 @@
 ---
 date: "2026-03-03"
-description: ""
+description: "The Broad Institute's Cancer Dependency Map (DepMap) project makes WGS, WES, and RNA sequencing data available on AnVIL."
 featured: false
-title: "Data Release - The Cancer Dependency Map (DepMap) project"
+title: "Data Release - The Cancer Dependency Map (DepMap) Project"
 ---
 
 <NewsHero {...frontmatter} />
@@ -13,7 +13,7 @@ Access requests for this controlled data are available through dbGaP under acces
 
 The DepMap project is committed to systematically accelerating precision cancer medicine by developing comprehensive, large-scale functional datasets that are publicly accessible to the research community. DepMap genomically profiles large panels of human cancer models using WGS, WES and RNA sequencing, and other omics modalities. The project employs genome-wide CRISPR knockout screening and drug sensitivity testing in barcoded cell lines to discover new targets and biomarkers for precision cancer therapy.
 
-Launched in 2017 at the Broad Institute, and building off the Cancer Cell Line Encyclopedia (CCLE) ([PMID:31068700](https://pubmed.ncbi.nlm.nih.gov/31068700/)) and Project Achilles, the DepMap project aimed to provide widespread insights into how specific genes influence cancer cell survival and response to treatments ([PMID:28753430](https://www.ncbi.nlm.nih.gov/pubmed?cmd=DetailsSearch&term=28753430%5BPMID%5D)). The DepMap project continues to expand, integrating genomic, transcriptomic, and drug response data, and has become a vital resource for the cancer research community ([PMID:39468210](https://pubmed.ncbi.nlm.nih.gov/39468210/)). DepMap’s collaborative approach encourages contributions from researchers worldwide, fostering innovation and discovery in cancer treatment strategies. To further advance this mission, the Broad established the DepMap Consortium - an industry/academic partnership dedicated to expanding DepMap's capabilities to accelerate precision cancer medicine. 
+Launched in 2017 at the Broad Institute, and building off the Cancer Cell Line Encyclopedia (CCLE) ([PMID:31068700](https://pubmed.ncbi.nlm.nih.gov/31068700/)) and Project Achilles, the DepMap project aimed to provide widespread insights into how specific genes influence cancer cell survival and response to treatments ([PMID:28753430](https://www.ncbi.nlm.nih.gov/pubmed?cmd=DetailsSearch&term=28753430%5BPMID%5D)). The DepMap project continues to expand, integrating genomic, transcriptomic, and drug response data, and has become a vital resource for the cancer research community ([PMID:39468210](https://pubmed.ncbi.nlm.nih.gov/39468210/)). DepMap’s collaborative approach encourages contributions from researchers worldwide, fostering innovation and discovery in cancer treatment strategies. To further advance this mission, the Broad established the DepMap Consortium - an industry/academic partnership dedicated to expanding DepMap's capabilities to accelerate precision cancer medicine.
 
 Processed DepMap data and analyses are free and available to be explored on the DepMap.org portal.
 


### PR DESCRIPTION
## Ticket
Closes #3895

## Summary
- Adds a news article announcing the Cancer Dependency Map (DepMap) project data availability on AnVIL

## Test plan
- [ ] Verify the news article renders correctly on the portal
- [ ] Check all links are functional (dbGaP accession, PubMed references, AnVIL data links)

🤖 Generated with [Claude Code](https://claude.ai/code)