### PR TITLE
fix: make DepMap blog link relative in March release notes

### DIFF
--- a/docs/releases/2026/03/data-additions.json
+++ b/docs/releases/2026/03/data-additions.json
@@ -86,6 +86,6 @@
     "phsId": "phs003444.v3.p1",
     "studyName": "The Cancer Dependency Map (DepMap)",
     "studyUrl": null,
-    "submitterBlogPost": "https://anvilproject.org/news/2026/03/03/depmap-data-release"
+    "submitterBlogPost": "/news/2026/03/03/depmap-data-release"
   }
 ]


### PR DESCRIPTION
## Ticket
Closes #3898

## Summary
- Convert the DepMap submitter blog post URL from absolute to relative path in the March 2026 data additions

## Test plan
- [ ] Verify the DepMap blog link in the March 2026 release notes navigates correctly

🤖 Generated with [Claude Code](https://claude.ai/code)