### PR TITLE
content: add March 2026 release to carousel

### DIFF
--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -17,11 +17,11 @@ export function buildCarouselCards(): SectionCard[] {
       links: [
         {
           label: ACTION_LABEL.LEARN_MORE,
-          url: "/releases/2025/11/release-notes",
+          url: "/releases/2026/03/release-notes",
         },
       ],
       text: "Explore newly released and updated studies on the AnVIL platform - find datasets in the Data Explorer and Data Library.",
-      title: "AnVIL November 2025 Release",
+      title: "AnVIL March 2026 Release",
     },
     {
       links: [


### PR DESCRIPTION
## Ticket
Closes #3910

## Summary
- Updates the homepage carousel to feature the March 2026 data release
- Replaces the November 2025 release entry with the March 2026 release

## Test plan
- [ ] Verify the carousel displays the March 2026 release
- [ ] Confirm the "Learn More" link navigates to `/releases/2026/03/release-notes`

🤖 Generated with [Claude Code](https://claude.ai/code)