### PR TITLE
content: update RAS banner text

### DIFF
--- a/components/Layout/components/Header/content/rasBanner.mdx
+++ b/components/Layout/components/Header/content/rasBanner.mdx
@@ -3,9 +3,8 @@
     As part of new federal government security policies, Terra is required to
     integrate with the NIH Researcher Authentication Service (RAS) for identity
     proofing and enhanced security. In order to link your NIH authorization to
-    Terra, users of eRA Commons must transition by March 25, 2026 to the use of
-    [Login.gov](https://login.gov) or ID.me credentials to access AnVIL
-    controlled-access data in Terra. See
+    Terra, users must use [Login.gov](https://login.gov) or ID.me credentials
+    to access AnVIL controlled-access data in Terra. See
     [here](https://support.terra.bio/hc/en-us/articles/32634034451099-RAS-Integration-for-AnVIL-Data)
     for more details and instructions.
   </span>


### PR DESCRIPTION
## Ticket
Closes #3915

## Summary
- Updated RAS banner to remove the March 25, 2026 deadline and eRA Commons reference
- Simplified the messaging to "users must use Login.gov or ID.me credentials"

## Test plan
- [ ] Verify banner displays correctly on the site
- [ ] Confirm Login.gov and documentation links still work

🤖 Generated with [Claude Code](https://claude.ai/code)