### PR TITLE
content: add anvil open-access data news to home page carousel

### DIFF
--- a/components/Home/components/Section/components/SectionAnalysisPortals/common/utils.ts
+++ b/components/Home/components/Section/components/SectionAnalysisPortals/common/utils.ts
@@ -101,7 +101,7 @@ export function buildAnalysisPortalCards(browserURL: string): SectionCard[] {
         height: 40,
         src: "/consortia/portals/anvil-explorer.png",
       },
-      text: "Build cross study cohorts for analysis in Terra.",
+      text: "Build cross study cohorts for download or analysis in supported cloud environments.",
       title: "AnVIL Data Explorer",
     },
     {

--- a/components/Home/components/Section/components/SectionAnalysisPortals/common/utils.ts
+++ b/components/Home/components/Section/components/SectionAnalysisPortals/common/utils.ts
@@ -101,7 +101,7 @@ export function buildAnalysisPortalCards(browserURL: string): SectionCard[] {
         height: 40,
         src: "/consortia/portals/anvil-explorer.png",
       },
-      text: "Build cross study cohorts for download or analysis in supported cloud environments.",
+      text: "Build cross-study cohorts for download or analysis in supported cloud environments.",
       title: "AnVIL Data Explorer",
     },
     {

--- a/components/Home/components/Section/components/SectionExplore/common/utils.ts
+++ b/components/Home/components/Section/components/SectionExplore/common/utils.ts
@@ -30,7 +30,7 @@ export function buildToolsAndWorkflowsCards(
         label: ACTION_LABEL.UNSPECIFIED,
         url: `${browserURL}/datasets`,
       },
-      text: "Access public and managed-access data hosted in the AnVIL Data Explorer",
+      text: "Export or download data hosted in the AnVIL Data Explorer",
       title: "Datasets",
     },
     {

--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -17,6 +17,17 @@ export function buildCarouselCards(): SectionCard[] {
       links: [
         {
           label: ACTION_LABEL.LEARN_MORE,
+          target: ANCHOR_TARGET.SELF,
+          url: "/news/2026/04/07/anvil-open-access-data-aws-registry",
+        },
+      ],
+      text: "Open-access data hosted by NHGRI's AnVIL Project is now available through the Registry of Open Data on AWS and the AWS Marketplace and is freely downloadable from the AnVIL Data Explorer.",
+      title: "NHGRI AnVIL Open-Access Data Available in AWS Open Data Registry",
+    },
+    {
+      links: [
+        {
+          label: ACTION_LABEL.LEARN_MORE,
           url: "/releases/2026/03/release-notes",
         },
       ],

--- a/docs/news/2026/04/07/anvil-open-access-data-aws-registry.mdx
+++ b/docs/news/2026/04/07/anvil-open-access-data-aws-registry.mdx
@@ -1,6 +1,6 @@
 ---
 date: "2026-04-07"
-description: "Open-access data hosted by NHGRI's AnVIL Project is now available through the Registry of Open Data on AWS and the AWS Marketplace."
+description: "Open-access data hosted by NHGRI's AnVIL Project is now available through the Registry of Open Data on AWS and the AWS Marketplace and is freely downloadable from the AnVIL Data Explorer."
 featured: true
 title: "NHGRI AnVIL Open-Access Data Available in AWS Open Data Registry"
 ---


### PR DESCRIPTION
## Summary
- Adds the new "NHGRI AnVIL Open-Access Data Available in AWS Open Data Registry" news article to the home page carousel
- Updates AnVIL Data Explorer description to reflect download and multi-cloud support
- Updates Datasets section text to reflect export/download capabilities

Closes #3921

## Test plan
- [x] Verify the new carousel card appears on the home page
- [x] Confirm the "Learn More" link navigates to the news article
- [x] Verify updated section descriptions render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)