### PR TITLE
fix: update ncpi-acc.org references to ncpi-data.org (#3929)

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -7,4 +7,5 @@ export const EMAIL_ADDRESSES: Parameter = {
 
 export const PATH_PARAMETERS: Parameter = {
   anvilHelpURL: "https://help.anvilproject.org",
+  ncpiURL: "https://ncpi-data.org",
 };

--- a/components/Home/components/Section/components/SectionAnalysisPortals/common/utils.ts
+++ b/components/Home/components/Section/components/SectionAnalysisPortals/common/utils.ts
@@ -1,4 +1,5 @@
 import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { PATH_PARAMETERS } from "../../../../../../../common/constants";
 import { SectionCard } from "../../../../../common/entities";
 
 const ACTION_LABEL = {
@@ -142,10 +143,9 @@ export function buildAnalysisPortalCards(browserURL: string): SectionCard[] {
     },
     {
       links: [
-        { label: ACTION_LABEL.LEARN_MORE, url: "https://www.ncpi-acc.org" },
         {
           label: ACTION_LABEL.DATASETS,
-          url: "https://ncpi-data.org/platforms",
+          url: PATH_PARAMETERS.ncpiURL,
         },
       ],
       media: {

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -46,7 +46,7 @@ AnVIL provides access to key [NHGRI datasets]({browserURL}/datasets), such as th
 
 ## Platform Interoperability
 
-AnVIL is a member of the [NIH Cloud Platform Interoperability Effort (NCPI)](https://www.ncpi-acc.org) and is collaborating with the [NCPI working groups](https://www.ncpi-acc.org/about/working-groups) to establish and implement technical standards enabling cross-platform authentication and authorization, cross-platform data discovery, and the cross-platform exchange of datasets, analysis tools, and derived data.
+AnVIL is a member of the [NIH Cloud Platform Interoperability Effort (NCPI)]({ncpiURL}) and is collaborating with the [NCPI working groups]({ncpiURL}/about/working-groups) to establish and implement technical standards enabling cross-platform authentication and authorization, cross-platform data discovery, and the cross-platform exchange of datasets, analysis tools, and derived data.
 
 [AnVIL is a registered knowledgebase and repository](https://fairsharing.org/4204) in the [FAIRsharing registry](https://fairsharing.org) of data and metadata standards, inter-related to databases and data policies.
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -46,7 +46,7 @@ AnVIL provides access to key [NHGRI datasets]({browserURL}/datasets), such as th
 
 ## Platform Interoperability
 
-AnVIL is a member of the [NIH Cloud Platform Interoperability Effort (NCPI)]({ncpiURL}) and is collaborating with the NCPI working groups to establish and implement technical standards enabling cross-platform authentication and authorization, [cross-platform data discovery]({ncpiURL}), and the cross-platform exchange of datasets, analysis tools, and derived data.
+AnVIL is a member of the NIH Cloud Platform Interoperability Effort (NCPI) and is collaborating with the NCPI working groups to establish and implement technical standards enabling cross-platform authentication and authorization, [cross-platform data discovery]({ncpiURL}), and the cross-platform exchange of datasets, analysis tools, and derived data.
 
 [AnVIL is a registered knowledgebase and repository](https://fairsharing.org/4204) in the [FAIRsharing registry](https://fairsharing.org) of data and metadata standards, inter-related to databases and data policies.
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -46,7 +46,7 @@ AnVIL provides access to key [NHGRI datasets]({browserURL}/datasets), such as th
 
 ## Platform Interoperability
 
-AnVIL is a member of the [NIH Cloud Platform Interoperability Effort (NCPI)]({ncpiURL}) and is collaborating with the NCPI working groups to establish and implement technical standards enabling cross-platform authentication and authorization, cross-platform data discovery, and the cross-platform exchange of datasets, analysis tools, and derived data.
+AnVIL is a member of the [NIH Cloud Platform Interoperability Effort (NCPI)]({ncpiURL}) and is collaborating with the NCPI working groups to establish and implement technical standards enabling cross-platform authentication and authorization, [cross-platform data discovery]({ncpiURL}), and the cross-platform exchange of datasets, analysis tools, and derived data.
 
 [AnVIL is a registered knowledgebase and repository](https://fairsharing.org/4204) in the [FAIRsharing registry](https://fairsharing.org) of data and metadata standards, inter-related to databases and data policies.
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -46,7 +46,7 @@ AnVIL provides access to key [NHGRI datasets]({browserURL}/datasets), such as th
 
 ## Platform Interoperability
 
-AnVIL is a member of the [NIH Cloud Platform Interoperability Effort (NCPI)]({ncpiURL}) and is collaborating with the [NCPI working groups]({ncpiURL}/about/working-groups) to establish and implement technical standards enabling cross-platform authentication and authorization, cross-platform data discovery, and the cross-platform exchange of datasets, analysis tools, and derived data.
+AnVIL is a member of the [NIH Cloud Platform Interoperability Effort (NCPI)]({ncpiURL}) and is collaborating with the NCPI working groups to establish and implement technical standards enabling cross-platform authentication and authorization, cross-platform data discovery, and the cross-platform exchange of datasets, analysis tools, and derived data.
 
 [AnVIL is a registered knowledgebase and repository](https://fairsharing.org/4204) in the [FAIRsharing registry](https://fairsharing.org) of data and metadata standards, inter-related to databases and data policies.
 


### PR DESCRIPTION
## Summary
- Replace all `ncpi-acc.org` references with `ncpi-data.org`
- Simplify `ncpi-data.org/platforms` links to `ncpi-data.org`
- Add `ncpiURL` to `PATH_PARAMETERS` for centralized URL management
- Remove redundant "Learn More" link from NCPI homepage card

Closes #3929

## Test plan
- [x] Verify NCPI card on homepage shows single "Datasets" link pointing to `https://ncpi-data.org`
- [x] Verify overview page NCPI links resolve correctly on `ncpi-data.org`
- [x] Confirm no remaining references to `ncpi-acc.org` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)