### PR TITLE
fix: move explorestprovider inside errorboundary to prevent crash loop

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,6 @@
 import "@databiosphere/findable-ui";
+import { Error } from "@databiosphere/findable-ui/lib/components/Error/error";
+import { ErrorBoundary } from "@databiosphere/findable-ui/lib/components/ErrorBoundary/errorBoundary";
 import { Header as DXHeader } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/header";
 import { setFeatureFlags } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/common/utils";
 import { useFeatureFlag } from "@databiosphere/findable-ui/lib/hooks/useFeatureFlag/useFeatureFlag";
@@ -79,11 +81,21 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                 >
                   <DXHeader {...layout.header} navigation={navigation} />
                 </ThemeProvider>
-                <ExploreStateProvider entityListType={entityListType}>
-                  <Main>
-                    <Component {...pageProps} />
-                  </Main>
-                </ExploreStateProvider>
+                <Main>
+                  <ErrorBoundary
+                    fallbackRender={({ error, reset }): JSX.Element => (
+                      <Error
+                        errorMessage={error.message}
+                        onReset={reset}
+                        rootPath="/"
+                      />
+                    )}
+                  >
+                    <ExploreStateProvider entityListType={entityListType}>
+                      <Component {...pageProps} />
+                    </ExploreStateProvider>
+                  </ErrorBoundary>
+                </Main>
                 <Footer {...layout.footer} />
               </AppLayout>
             </LayoutDimensionsProvider>


### PR DESCRIPTION
## Summary
- Add `ErrorBoundary` and `Error` fallback from `findable-ui` to `pages/_app.tsx`
- Move `ExploreStateProvider` inside the `ErrorBoundary` so provider errors are caught instead of causing an infinite crash loop
- Header and Footer remain outside the boundary so users can still navigate away from the error page

Closes #3936
Related: DataBiosphere/findable-ui#888

## Test plan
- [x] Verify site builds and renders correctly
- [x] Test with malformed filter query params (e.g. `?filter=%5B%7B`) — should show error page instead of crash loop
- [x] Verify normal navigation and filtering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)