### PR TITLE
fix: revert ExploreStateProvider outside ErrorBoundary and upgrade findable-ui to v51.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "the-anvil",
       "version": "2.31.2",
       "dependencies": {
-        "@databiosphere/findable-ui": "^51.0.1",
+        "@databiosphere/findable-ui": "^51.1.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@mdx-js/loader": "^3.0.1",
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "51.0.1",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.1.tgz",
-      "integrity": "sha512-kHHf38QoQUJP+LQAPFKmGuOdZWWeb8Fjer+1CgIa8CryAnGI4HGNQT1KetrnMP0KuPRVOw3VmQOtzsynSdauKg==",
+      "version": "51.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.1.0.tgz",
+      "integrity": "sha512-aWy0zOOGim5xoJvWes1v/mqKSobBUlGmfZt4uIMp5f+oNKEFlAA27CSJ01SsbhWQKgpPdZT3f+kXxfYG0FDk+A==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fetch-citations": "node scripts/fetch-citations.mjs --build-publications"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^51.0.1",
+    "@databiosphere/findable-ui": "^51.1.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@mdx-js/loader": "^3.0.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -81,21 +81,21 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                 >
                   <DXHeader {...layout.header} navigation={navigation} />
                 </ThemeProvider>
-                <Main>
-                  <ErrorBoundary
-                    fallbackRender={({ error, reset }): JSX.Element => (
-                      <Error
-                        errorMessage={error.message}
-                        onReset={reset}
-                        rootPath="/"
-                      />
-                    )}
-                  >
-                    <ExploreStateProvider entityListType={entityListType}>
+                <ExploreStateProvider entityListType={entityListType}>
+                  <Main>
+                    <ErrorBoundary
+                      fallbackRender={({ error, reset }): JSX.Element => (
+                        <Error
+                          errorMessage={error.message}
+                          onReset={reset}
+                          rootPath="/"
+                        />
+                      )}
+                    >
                       <Component {...pageProps} />
-                    </ExploreStateProvider>
-                  </ErrorBoundary>
-                </Main>
+                    </ErrorBoundary>
+                  </Main>
+                </ExploreStateProvider>
                 <Footer {...layout.footer} />
               </AppLayout>
             </LayoutDimensionsProvider>


### PR DESCRIPTION
## Summary

Reverts `ExploreStateProvider` to its original position outside the `ErrorBoundary` and upgrades findable-ui to v51.1.0, which fixes the infinite crash loop at the library level.

### Why revert

PR #3936 moved `ExploreStateProvider` inside the `ErrorBoundary` to catch reducer crashes. This fixed the crash loop but caused **state loss** when navigating between pages.

### Why this works without the provider move

findable-ui v51.1.0 ([PR #899](https://github.com/DataBiosphere/findable-ui/pull/899)) fixes the root cause:

- **`parseFilterParam`** — safely validates filter URL params without throwing (prevents reducer crash above ErrorBoundary)
- **`useValidateFilterParam`** hook — runs inside ExploreView (inside ErrorBoundary), validates the URL filter param directly, throws `DataExplorerError` for invalid filters so the error page renders
- **`ErrorBoundary`** — fixes `this.render` → `this.reset` typo
- **`useAsync.run()`** — clears stale error on new request

### Note on CS filtering behaviour

This app uses client-side fetch with client-side filtering, so the valid-shape-invalid-values test case behaves differently:

- **Valid `categoryKey`, bogus value** (e.g. `?filter=[{"categoryKey":"title","value":["A bioinformatic"]}]`) — renders the value as a filter chip that can be removed, but since the data doesn't contain the term, shows "No Results found". This is a good outcome.
- **Invalid `categoryKey`** (e.g. `?filter=[{"categoryKey":"bogus","value":["invalid"]}]`) — fails silently with no filters applied and no notice to the user.

Closes #3938

## Reference

- Umbrella: DataBiosphere/findable-ui#900
- Findable-ui fix: https://github.com/DataBiosphere/findable-ui/pull/899
- Provider move being reverted: #3936

## Test plan
- [x] Lint passes
- [x] Prettier passes
- [x] TypeScript compiles
- [x] Manual: malformed JSON filter → error page, no loop
- [x] Manual: wrong shape filter → error page, no loop
- [x] Manual: valid filters work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)