### PR TITLE
content: add news page and carousel card for anvil free genomic datasets on aws (#3940)

### DIFF
--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -18,6 +18,18 @@ export function buildCarouselCards(): SectionCard[] {
         {
           label: ACTION_LABEL.LEARN_MORE,
           target: ANCHOR_TARGET.SELF,
+          url: "/news/2026/05/01/anvil-free-genomic-datasets-aws",
+        },
+      ],
+      text: "AnVIL has partnered with AWS to make major genomic datasets freely available, eliminating data transfer fees that previously exceeded $15,000 for some datasets.",
+      title:
+        "AnVIL Makes Groundbreaking Genomic Datasets Available on AWS for Free",
+    },
+    {
+      links: [
+        {
+          label: ACTION_LABEL.LEARN_MORE,
+          target: ANCHOR_TARGET.SELF,
           url: "/news/2026/04/07/anvil-open-access-data-aws-registry",
         },
       ],

--- a/docs/news/2026/05/01/anvil-free-genomic-datasets-aws.mdx
+++ b/docs/news/2026/05/01/anvil-free-genomic-datasets-aws.mdx
@@ -1,0 +1,26 @@
+---
+date: "2026-05-01"
+description: "AnVIL has partnered with AWS to make major genomic datasets freely available, eliminating data transfer fees that previously exceeded $15,000 for some datasets."
+featured: true
+title: "AnVIL Makes Groundbreaking Genomic Datasets Available on AWS for Free"
+---
+
+<NewsHero {...frontmatter} />
+
+NHGRI's AnVIL platform has partnered with **Amazon Web Services (AWS)** to make major genomic datasets available at no cost, eliminating data transfer fees that previously exceeded **$15,000** for some datasets.
+
+This initiative removes financial barriers that previously prevented many researchers from accessing critical genomic information, democratizing access to essential research materials and reducing barriers for scientists with limited funding.
+
+## Accessing the Free Datasets
+
+Free datasets can be browsed in the **AnVIL Data Explorer** by filtering for open-access consent groups:
+
+- [View free datasets in the Data Explorer]({browserURL}/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.consent_group%22%2C%22value%22%3A%5B%22NRES%22%5D%7D%5D)
+
+Data can be downloaded using any of the following methods:
+
+- **[Dataset Download via curl]({browserURL}/guides/data-download-via-curl)** — Download a complete dataset using the `curl` command or use `curl` to download files of selected types across multiple datasets simultaneously.
+- **[TSV File Manifest]({browserURL}/guides/tsv-file-manifest-download)** — Export a manifest containing the S3 URI for each file.
+- **[Individual File Download]({browserURL}/guides/individual-file-download)** — In the Explorer's **Files** tab, use the download icon to select individual files.
+
+For the full article, see [AnVIL Makes Groundbreaking Genomic Datasets Available on AWS for Free](https://news.ucsc.edu/2026/04/anvil-makes-genomic-datasets-free/) on UCSC News.


### PR DESCRIPTION
## Summary
- Add news page for the AnVIL + AWS free genomic datasets announcement
- Add carousel card on homepage linking to the new news page
- News page includes links to UCSC source article, curl download guide, and Data Explorer filtered to free datasets

Closes #3940

## Test plan
- [x] Verify new news page renders at `/news/2026/05/01/anvil-free-genomic-datasets-aws`
- [x] Verify carousel card appears on homepage
- [x] Verify Data Explorer filter URL resolves correctly (consent group filter may need adjustment)
- [x] Verify curl guide and other download links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2478" height="797" alt="image" src="https://github.com/user-attachments/assets/e310486d-dc74-4db6-9c92-a68bf2b854b5" />

<img width="2483" height="1229" alt="image" src="https://github.com/user-attachments/assets/f5f5032c-b1c3-4454-a33c-23d448f01ad1" />
