### PR TITLE
content: update free datasets news with dataset list, filter link, and highlight box (#3942)

### DIFF
--- a/docs/news/2026/05/01/anvil-free-genomic-datasets-aws.mdx
+++ b/docs/news/2026/05/01/anvil-free-genomic-datasets-aws.mdx
@@ -11,16 +11,36 @@ NHGRI's AnVIL platform has partnered with **Amazon Web Services (AWS)** to make 
 
 This initiative removes financial barriers that previously prevented many researchers from accessing critical genomic information, democratizing access to essential research materials and reducing barriers for scientists with limited funding.
 
+<Alert icon={false} severity="info">
+  For the full article, see [AnVIL Makes Groundbreaking Genomic Datasets Available on AWS for Free](https://news.ucsc.edu/2026/04/anvil-makes-genomic-datasets-free/) on UCSC News.
+</Alert>
+
+## Available Datasets
+
+All open-access AnVIL datasets are currently available through this program:
+
+- [AnVIL 1000G PRIMED Data Model](https://explore.anvilproject.org/datasets/303b5a92-57c8-4df2-8331-8ff308f21293/export)
+- [AnVIL 1000G High Coverage 2019](https://explore.anvilproject.org/datasets/63d97e58-a825-4b93-a9a7-0d9d165dc826/export)
+- [AnVIL GTEx Public Data](https://explore.anvilproject.org/datasets/e5aee011-bdb3-4caa-954c-a46678656270/export)
+- [AnVIL HPRC](https://explore.anvilproject.org/datasets/74472c21-cafa-4879-9745-aa94ebd9f77c/export)
+- [AnVIL NIA CARD Coriell Cell Lines Open](https://explore.anvilproject.org/datasets/1bb475e9-2422-4be4-9d98-b964be39c11d/export)
+- [AnVIL T2T](https://explore.anvilproject.org/datasets/5c25d772-bdcb-4ea9-989c-f92258634ad9/export)
+- [AnVIL T2T ChrY](https://explore.anvilproject.org/datasets/1426a206-fcb1-4a07-9b47-32f06ef8cf8d/export)
+- [AnVIL ENCORE 293T](https://explore.anvilproject.org/datasets/15ac2bed-cd9a-4893-9a0e-be1d07577153/export)
+- [AnVIL ENCORE RS293](https://explore.anvilproject.org/datasets/b749d9b5-0561-4343-936b-47c6b476ece0/export)
+- [AnVIL IGVF Mouse R1](https://explore.anvilproject.org/datasets/2864e9de-7a1a-4d4a-9ed2-03bd23cf7f5c/export)
+- [AnVIL MAGE](https://explore.anvilproject.org/datasets/4af9fbfc-de22-4a6d-b481-5fe756a45b23/export)
+
+Additional datasets and updates to existing datasets will be made available as they are released by NHGRI's AnVIL Project.
+
 ## Accessing the Free Datasets
 
 Free datasets can be browsed in the **AnVIL Data Explorer** by filtering for open-access consent groups:
 
-- [View free datasets in the Data Explorer]({browserURL}/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.consent_group%22%2C%22value%22%3A%5B%22NRES%22%5D%7D%5D)
+- [View free datasets in the Data Explorer]({browserURL}/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.consent_group%22%2C%22value%22%3A%5B%22NRES%22%2C%22Unrestricted+access%22%5D%7D%5D)
 
 Data can be downloaded using any of the following methods:
 
 - **[Dataset Download via curl]({browserURL}/guides/data-download-via-curl)** — Download a complete dataset using the `curl` command or use `curl` to download files of selected types across multiple datasets simultaneously.
 - **[TSV File Manifest]({browserURL}/guides/tsv-file-manifest-download)** — Export a manifest containing the S3 URI for each file.
 - **[Individual File Download]({browserURL}/guides/individual-file-download)** — In the Explorer's **Files** tab, use the download icon to select individual files.
-
-For the full article, see [AnVIL Makes Groundbreaking Genomic Datasets Available on AWS for Free](https://news.ucsc.edu/2026/04/anvil-makes-genomic-datasets-free/) on UCSC News.


### PR DESCRIPTION
## Summary
- Add Available Datasets section with links to all open-access datasets (matching the related news page)
- Update Data Explorer filter link to include both NRES and Unrestricted access consent groups
- Move UCSC article link into an `<Alert>` highlight box (no icon) below the intro paragraph
- Remove the UCSC link from the bottom of the page

Closes #3942

## Test plan
- [x] Verify news page renders at `/news/2026/05/01/anvil-free-genomic-datasets-aws`
- [x] Verify Alert box renders correctly with UCSC link
- [x] Verify dataset links resolve to the Data Explorer
- [x] Verify filter link opens Data Explorer with NRES + Unrestricted access filters applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2485" height="1288" alt="image" src="https://github.com/user-attachments/assets/40589225-ff77-4633-8ab0-3058fc237fcf" />
