### PR TITLE
content: add hotel booking links to ACC 2026 event page (#3949)

### DIFF
--- a/docs/events/anvil2026-community-conference.mdx
+++ b/docs/events/anvil2026-community-conference.mdx
@@ -92,9 +92,13 @@ Get onto the AnVIL platform at our workshops where you'll learn the basics of cl
     - End Date: Thursday, September 3, 2026
     - Special group rate: $239.00 USD per night
     - Last Day to Book: Monday, August 10, 2026
+    - Link to Book:<br/>
+      https://www.marriott.com/event-reservations/reservation-link.mi?id=1775331883145&key=GRP&app=resvlink&_branch_match_id=1456056423690096870&_branch_referrer=H4sIAAAAAAAAA8soKSkottLXTywo0MtNLCrKzC8p0UvOz9UvSi3OyczLtgdK2ALZZSCOWmaKraG5uamxsaGFhbGhiapadmqlrXtQgFpdUWpaKlB3Xnp8UlF%2BeXFqka1zRlF%2BbioAvuHWy2AAAAA%3D
   - Boston Marriott Cambridge
     - AnVIL Community Conference Room Block
     - Start Date: Monday, August 31, 2026
     - End Date: Thursday, September 3, 2026
     - Special group rate: $219.00 USD per night
     - Last Day to Book: Monday, August 10, 2026
+    - Link to Book:<br/>
+      https://www.marriott.com/event-reservations/reservation-link.mi?id=1775748371872&key=GRP&app=resvlink&_branch_match_id=1456056423690096870&_branch_referrer=H4sIAAAAAAAAA8soKSkottLXTywo0MtNLCrKzC8p0UvOz9UvSi3OyczLtgdK2ALZZSCOWmaKraG5uam5iYWxuaGFuZFadmqlrXtQgFpdUWpaKlB3Xnp8UlF%2BeXFqka1zRlF%2BbioA9aGMmGAAAAA%3D


### PR DESCRIPTION
## Summary

- Add hotel room block booking links for both hotels (Residence Inn and Boston Marriott Cambridge) to the ACC 2026 event page

Closes #3949

## Test plan

- [ ] Verify booking links render correctly on the ACC 2026 event page
- [ ] Verify links open the correct Marriott reservation pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)