### PR TITLE
feat: add 3-month freshness window and persistent flag (#3961)

### DIFF
--- a/components/Home/common/entities.ts
+++ b/components/Home/common/entities.ts
@@ -4,8 +4,10 @@ import { LinkProps } from "@databiosphere/findable-ui/lib/components/Links/compo
 type Link = Omit<LinkProps, "url"> & { url: string };
 
 export interface SectionCard {
+  date?: string;
   links: Link[];
   media?: StaticImageProps;
+  persistent?: boolean;
   secondaryText?: string;
   text: string;
   title: string;

--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -1,4 +1,5 @@
 import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { isRecentOrPersistent } from "../../../../../../../content/utils";
 import { SectionCard } from "../../../../../common/entities";
 
 const ACTION_LABEL = {
@@ -7,189 +8,208 @@ const ACTION_LABEL = {
   WORKSPACE: "Workspace",
 };
 
+const CAROUSEL_CARDS: SectionCard[] = [
+  {
+    date: "2026-05-01",
+    links: [
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        target: ANCHOR_TARGET.SELF,
+        url: "/news/2026/05/01/anvil-free-genomic-datasets-aws",
+      },
+    ],
+    text: "AnVIL has partnered with AWS to make major genomic datasets freely available, eliminating data transfer fees that previously exceeded $15,000 for some datasets.",
+    title:
+      "AnVIL Makes Groundbreaking Genomic Datasets Available on AWS for Free",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        target: ANCHOR_TARGET.SELF,
+        url: "/events/anvil2026-community-conference",
+      },
+    ],
+    persistent: true,
+    text: "Join us August 31 - September 1, 2026 in Cambridge, MA for the AnVIL Community Conference — featuring keynote speakers, workshops, poster sessions, and the latest in genomics analysis in the cloud.",
+    title: "AnVIL Community Conference 2026",
+  },
+  {
+    date: "2026-04-07",
+    links: [
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        target: ANCHOR_TARGET.SELF,
+        url: "/news/2026/04/07/anvil-open-access-data-aws-registry",
+      },
+    ],
+    text: "Open-access data hosted by NHGRI's AnVIL Project is now available through the Registry of Open Data on AWS and the AWS Marketplace and is freely downloadable from the AnVIL Data Explorer.",
+    title: "NHGRI AnVIL Open-Access Data Available in AWS Open Data Registry",
+  },
+  {
+    date: "2026-03-01",
+    links: [
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        url: "/releases/2026/03/release-notes",
+      },
+    ],
+    text: "Explore newly released and updated studies on the AnVIL platform - find datasets in the Data Explorer and Data Library.",
+    title: "AnVIL March 2026 Release",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.PAPER,
+        url: "https://www.nature.com/articles/s41586-025-09613-8",
+      },
+    ],
+    media: {
+      alt: "GREGoR Consortium",
+      height: 168,
+      src: "/consortia/carousel/gregor.webp",
+    },
+    persistent: true,
+    text: "The GREGoR Consortium's latest publication in Nature (Vol 647) presents a large-scale collaborative framework, datasets and discoveries from over 7,500 individuals from over 3,000 families, are rapidly made available to researchers worldwide through the Analysis, Visualization and Informatics Lab-space (AnVIL) to catalyse global efforts to develop approaches for genetic diagnoses in rare diseases",
+    title: "GREGoR: accelerating genomics for rare diseases",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        target: ANCHOR_TARGET.SELF,
+        url: "/news/2025/08/25/all-of-us-anvil-imputation-service",
+      },
+    ],
+    persistent: true,
+    text: "The Broad Institute's Data Sciences Platform has launched the All of Us + AnVIL Imputation Service.",
+    title: "Introducing the All of Us + AnVIL Imputation Service",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.PAPER,
+        url: "https://www.cell.com/ajhg/fulltext/S0002-9297(24)00379-3",
+      },
+    ],
+    persistent: true,
+    text: "Using the AnVIL, the PRIMED Consortium is developing methods to improve the performance of PRSs in global populations and individuals of diverse genetic ancestry.",
+    title:
+      "The PRIMED Consortium: Reducing disparities in polygenic risk assessment",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.PAPER,
+        url: "https://www.science.org/doi/10.1126/science.abl3533",
+      },
+      {
+        label: ACTION_LABEL.WORKSPACE,
+        url: "https://anvil.terra.bio/#workspaces/anvil-datastorage/AnVIL_T2T",
+      },
+    ],
+    persistent: true,
+    text: "Using the AnVIL, researchers find the T2T-CHM13 reference genome universally improves the analysis of human genetic variation.",
+    title:
+      "A complete reference genome improves analysis of human genetic variation",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.PAPER,
+        url: "https://www.cell.com/cell-genomics/fulltext/S2666-979X(21)00106-3",
+      },
+    ],
+    persistent: true,
+    text: "AnVIL inverts the traditional model of genomic analysis, eliminating data movement and providing scalable, shared computing resources.",
+    title:
+      "Inverting the model of genomics data sharing with the NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-space (AnVIL)",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        target: ANCHOR_TARGET.SELF,
+        url: "/learn/watch-videos-and-tutorials/anvil-videos",
+      },
+    ],
+    persistent: true,
+    text: "Our short video series shows how AnVIL improves collaborative science for different researcher roles.",
+    title: "AnVIL Shorts: How can AnVIL help my research?",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.PAPER,
+        url: "https://www.science.org/doi/10.1126/science.abe3261",
+      },
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        url: "https://support.terra.bio/hc/en-us/articles/360041068771--COVID-19-workspaces-data-and-tools-in-Terra",
+      },
+    ],
+    persistent: true,
+    text: "Using the AnVIL, researchers investigate the effect of superspreading events in the Boston area.",
+    title:
+      "Phylogenetic analysis of SARS-CoV-2 in Boston highlights the impact of superspreading events",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.PAPER,
+        url: "https://academic.oup.com/nar/article/49/W1/W624/6274534",
+      },
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        url: "https://dockstore.org",
+      },
+    ],
+    persistent: true,
+    text: "Dockstore is an open source platform for publishing, sharing, and finding bioinformatics tools and workflows.",
+    title:
+      "The Dockstore: enhancing a community platform for sharing reproducible and accessible computational protocols",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.PAPER,
+        url: "https://www.nature.com/articles/s41592-019-0654-x",
+      },
+      {
+        label: ACTION_LABEL.WORKSPACE,
+        url: "https://anvil.terra.bio/#workspaces/bioconductor-rpci-anvil/Bioconductor-Book-OrchestratingSingleCellAnalysis",
+      },
+    ],
+    persistent: true,
+    text: "The AnVIL hosts a detailed book of single-cell methods and analysis techniques.",
+    title: "Orchestrating single-cell analysis with Bioconductor",
+  },
+  {
+    links: [
+      {
+        label: ACTION_LABEL.PAPER,
+        url: "https://academic.oup.com/nar/article/48/W1/W395/5849904",
+      },
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        target: ANCHOR_TARGET.SELF,
+        url: "/learn/run-interactive-analyses/getting-started-with-galaxy",
+      },
+    ],
+    persistent: true,
+    text: "AnVIL has access to full Galaxy capabilities, a computational workbench used by thousands of scientists to analyze biomedical data.",
+    title:
+      "The Galaxy platform for accessible, reproducible and collaborative biomedical analyses: 2020 update",
+  },
+];
+
 /**
- * Returns the carousel cards for the hero section.
+ * Returns the carousel cards for the hero section, filtered to entries that
+ * are either within the recent-content window or marked persistent.
  * @returns carousel cards.
  */
 export function buildCarouselCards(): SectionCard[] {
-  return [
-    {
-      links: [
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          target: ANCHOR_TARGET.SELF,
-          url: "/news/2026/05/01/anvil-free-genomic-datasets-aws",
-        },
-      ],
-      text: "AnVIL has partnered with AWS to make major genomic datasets freely available, eliminating data transfer fees that previously exceeded $15,000 for some datasets.",
-      title:
-        "AnVIL Makes Groundbreaking Genomic Datasets Available on AWS for Free",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          target: ANCHOR_TARGET.SELF,
-          url: "/events/anvil2026-community-conference",
-        },
-      ],
-      text: "Join us August 31 - September 1, 2026 in Cambridge, MA for the AnVIL Community Conference — featuring keynote speakers, workshops, poster sessions, and the latest in genomics analysis in the cloud.",
-      title: "AnVIL Community Conference 2026",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          target: ANCHOR_TARGET.SELF,
-          url: "/news/2026/04/07/anvil-open-access-data-aws-registry",
-        },
-      ],
-      text: "Open-access data hosted by NHGRI's AnVIL Project is now available through the Registry of Open Data on AWS and the AWS Marketplace and is freely downloadable from the AnVIL Data Explorer.",
-      title: "NHGRI AnVIL Open-Access Data Available in AWS Open Data Registry",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          url: "/releases/2026/03/release-notes",
-        },
-      ],
-      text: "Explore newly released and updated studies on the AnVIL platform - find datasets in the Data Explorer and Data Library.",
-      title: "AnVIL March 2026 Release",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.PAPER,
-          url: "https://www.nature.com/articles/s41586-025-09613-8",
-        },
-      ],
-      media: {
-        alt: "GREGoR Consortium",
-        height: 168,
-        src: "/consortia/carousel/gregor.webp",
-      },
-      text: "The GREGoR Consortium's latest publication in Nature (Vol 647) presents a large-scale collaborative framework, datasets and discoveries from over 7,500 individuals from over 3,000 families, are rapidly made available to researchers worldwide through the Analysis, Visualization and Informatics Lab-space (AnVIL) to catalyse global efforts to develop approaches for genetic diagnoses in rare diseases",
-      title: "GREGoR: accelerating genomics for rare diseases",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          target: ANCHOR_TARGET.SELF,
-          url: "/news/2025/08/25/all-of-us-anvil-imputation-service",
-        },
-      ],
-      text: "The Broad Institute's Data Sciences Platform has launched the All of Us + AnVIL Imputation Service.",
-      title: "Introducing the All of Us + AnVIL Imputation Service",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.PAPER,
-          url: "https://www.cell.com/ajhg/fulltext/S0002-9297(24)00379-3",
-        },
-      ],
-      text: "Using the AnVIL, the PRIMED Consortium is developing methods to improve the performance of PRSs in global populations and individuals of diverse genetic ancestry.",
-      title:
-        "The PRIMED Consortium: Reducing disparities in polygenic risk assessment",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.PAPER,
-          url: "https://www.science.org/doi/10.1126/science.abl3533",
-        },
-        {
-          label: ACTION_LABEL.WORKSPACE,
-          url: "https://anvil.terra.bio/#workspaces/anvil-datastorage/AnVIL_T2T",
-        },
-      ],
-      text: "Using the AnVIL, researchers find the T2T-CHM13 reference genome universally improves the analysis of human genetic variation.",
-      title:
-        "A complete reference genome improves analysis of human genetic variation",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.PAPER,
-          url: "https://www.cell.com/cell-genomics/fulltext/S2666-979X(21)00106-3",
-        },
-      ],
-      text: "AnVIL inverts the traditional model of genomic analysis, eliminating data movement and providing scalable, shared computing resources.",
-      title:
-        "Inverting the model of genomics data sharing with the NHGRI Genomic Data Science Analysis, Visualization, and Informatics Lab-space (AnVIL)",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          target: ANCHOR_TARGET.SELF,
-          url: "/learn/watch-videos-and-tutorials/anvil-videos",
-        },
-      ],
-      text: "Our short video series shows how AnVIL improves collaborative science for different researcher roles.",
-      title: "AnVIL Shorts: How can AnVIL help my research?",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.PAPER,
-          url: "https://www.science.org/doi/10.1126/science.abe3261",
-        },
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          url: "https://support.terra.bio/hc/en-us/articles/360041068771--COVID-19-workspaces-data-and-tools-in-Terra",
-        },
-      ],
-      text: "Using the AnVIL, researchers investigate the effect of superspreading events in the Boston area.",
-      title:
-        "Phylogenetic analysis of SARS-CoV-2 in Boston highlights the impact of superspreading events",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.PAPER,
-          url: "https://academic.oup.com/nar/article/49/W1/W624/6274534",
-        },
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          url: "https://dockstore.org",
-        },
-      ],
-      text: "Dockstore is an open source platform for publishing, sharing, and finding bioinformatics tools and workflows.",
-      title:
-        "The Dockstore: enhancing a community platform for sharing reproducible and accessible computational protocols",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.PAPER,
-          url: "https://www.nature.com/articles/s41592-019-0654-x",
-        },
-        {
-          label: ACTION_LABEL.WORKSPACE,
-          url: "https://anvil.terra.bio/#workspaces/bioconductor-rpci-anvil/Bioconductor-Book-OrchestratingSingleCellAnalysis",
-        },
-      ],
-      text: "The AnVIL hosts a detailed book of single-cell methods and analysis techniques.",
-      title: "Orchestrating single-cell analysis with Bioconductor",
-    },
-    {
-      links: [
-        {
-          label: ACTION_LABEL.PAPER,
-          url: "https://academic.oup.com/nar/article/48/W1/W395/5849904",
-        },
-        {
-          label: ACTION_LABEL.LEARN_MORE,
-          target: ANCHOR_TARGET.SELF,
-          url: "/learn/run-interactive-analyses/getting-started-with-galaxy",
-        },
-      ],
-      text: "AnVIL has access to full Galaxy capabilities, a computational workbench used by thousands of scientists to analyze biomedical data.",
-      title:
-        "The Galaxy platform for accessible, reproducible and collaborative biomedical analyses: 2020 update",
-    },
-  ];
+  return CAROUSEL_CARDS.filter((card) =>
+    isRecentOrPersistent(card.date, card.persistent)
+  );
 }

--- a/components/Home/components/Section/components/SectionUpdates/common/entities.ts
+++ b/components/Home/components/Section/components/SectionUpdates/common/entities.ts
@@ -6,6 +6,7 @@ export interface CardFrontmatter {
   featured?: boolean;
   hidden: boolean;
   path: string;
+  persistent?: boolean;
   secondaryText?: string;
   title: string;
 }

--- a/components/Home/components/Section/components/SectionUpdates/common/utils.ts
+++ b/components/Home/components/Section/components/SectionUpdates/common/utils.ts
@@ -5,6 +5,8 @@ import {
   getContentDirectory,
   getFrontmatterByPaths,
   isFeatured,
+  isPersistent,
+  isRecentOrPersistent,
 } from "../../../../../../../content/utils";
 import { mapSlugByFilePaths } from "../../../../../../../docs/common/utils";
 import { CardFrontmatter, UpdateCard } from "./entities";
@@ -21,14 +23,14 @@ export function buildUpdateSectionCards(dirName: string): UpdateCard[] {
 }
 
 /**
- * Returns true if the frontmatter is featured, not hidden, and the date is defined.
+ * Returns true if the frontmatter is featured, not hidden, has a date, and is
+ * either within the recent-content window or marked persistent.
  * @param frontmatter - Frontmatter.
- * @returns true if the frontmatter is featured, not hidden, and the date is defined.
+ * @returns true if the frontmatter should be shown in the featured section.
  */
 function filterFrontmatter(frontmatter: CardFrontmatter): boolean {
-  return Boolean(
-    frontmatter.date && frontmatter.featured && !frontmatter.hidden
-  );
+  if (!frontmatter.featured || frontmatter.hidden) return false;
+  return isRecentOrPersistent(frontmatter.date, frontmatter.persistent);
 }
 
 /**
@@ -44,6 +46,7 @@ function mapToCardFrontmatter(
   const moment = buildMomentField(frontmatter);
   const date = moment?.toDate();
   const featured = isFeatured(frontmatter);
+  const persistent = isPersistent(frontmatter);
   const secondaryText = moment?.format(DATE_FORMAT); // Formatted date field.
   return {
     date,
@@ -51,6 +54,7 @@ function mapToCardFrontmatter(
     featured,
     hidden,
     path,
+    persistent,
     secondaryText,
     title,
   };

--- a/components/Home/components/Section/components/SectionUpdates/common/utils.ts
+++ b/components/Home/components/Section/components/SectionUpdates/common/utils.ts
@@ -12,25 +12,46 @@ import { mapSlugByFilePaths } from "../../../../../../../docs/common/utils";
 import { CardFrontmatter, UpdateCard } from "./entities";
 
 /**
- * Returns the update section cards for the given directory.
+ * Returns the update section cards for the given directory, applying the
+ * supplied frontmatter filter.
  * @param dirName - Directory name.
+ * @param filterFrontmatterFn - Frontmatter filter applied per item.
  * @returns update section cards.
  */
-export function buildUpdateSectionCards(dirName: string): UpdateCard[] {
+export function buildUpdateSectionCards(
+  dirName: string,
+  filterFrontmatterFn: (frontmatter: CardFrontmatter) => boolean
+): UpdateCard[] {
   const slugByFilePaths = mapSlugByFilePaths(getContentDirectory(dirName));
   const frontmatterByPaths = getFrontmatterByPaths(slugByFilePaths, dirName);
-  return processUpdateSectionCards([...frontmatterByPaths]);
+  return processUpdateSectionCards(
+    [...frontmatterByPaths],
+    filterFrontmatterFn
+  );
 }
 
 /**
- * Returns true if the frontmatter is featured, not hidden, has a date, and is
- * either within the recent-content window or marked persistent.
+ * Returns true if the event frontmatter is featured, not hidden, has a date,
+ * and is either within the recent-content window or marked persistent.
  * @param frontmatter - Frontmatter.
- * @returns true if the frontmatter should be shown in the featured section.
+ * @returns true if the event should be shown in the featured section.
  */
-function filterFrontmatter(frontmatter: CardFrontmatter): boolean {
+export function filterEventFrontmatter(frontmatter: CardFrontmatter): boolean {
   if (!frontmatter.featured || frontmatter.hidden) return false;
   return isRecentOrPersistent(frontmatter.date, frontmatter.persistent);
+}
+
+/**
+ * Returns true if the news frontmatter is featured, not hidden, and has a
+ * date. News is not subject to the recent-content window — the featured
+ * section always renders the most recent items regardless of age.
+ * @param frontmatter - Frontmatter.
+ * @returns true if the news item should be shown in the featured section.
+ */
+export function filterNewsFrontmatter(frontmatter: CardFrontmatter): boolean {
+  return Boolean(
+    frontmatter.date && frontmatter.featured && !frontmatter.hidden
+  );
 }
 
 /**
@@ -83,7 +104,7 @@ function mapToSectionCard(frontmatter: CardFrontmatter): UpdateCard {
  */
 export function processUpdateSectionCards(
   frontmatterByPaths: [string, Frontmatter][],
-  filterFrontmatterFn = filterFrontmatter
+  filterFrontmatterFn: (frontmatter: CardFrontmatter) => boolean
 ): UpdateCard[] {
   return [...frontmatterByPaths]
     .map(mapToCardFrontmatter)

--- a/components/Home/components/Section/components/SectionUpdates/constants.ts
+++ b/components/Home/components/Section/components/SectionUpdates/constants.ts
@@ -1,0 +1,6 @@
+export const MAX_UPDATE_CARDS = 3;
+
+export enum UPDATE_VIEW {
+  EVENTS = "EVENTS",
+  NEWS = "NEWS",
+}

--- a/components/Home/components/Section/components/SectionUpdates/sectionUpdates.tsx
+++ b/components/Home/components/Section/components/SectionUpdates/sectionUpdates.tsx
@@ -8,31 +8,19 @@ import {
   SectionSubtitle,
   SectionTitle,
 } from "../../section.styles";
-import { UpdateCard } from "./common/entities";
 import { Updates } from "./components/Updates/updates";
+import { UPDATE_VIEW } from "./constants";
 import {
   Headline,
   SectionActions,
   ToggleButtonGroup,
 } from "./sectionUpdates.styles";
-
-const MAX_UPDATE_CARDS = 3;
-
-export enum UPDATE_VIEW {
-  EVENTS = "EVENTS",
-  NEWS = "NEWS",
-}
+import { getDisplayCards } from "./utils";
 
 export const SectionUpdates = (): JSX.Element => {
   const { eventCards, newsCards } = useSectionsData();
   const [view, setView] = useState<UPDATE_VIEW>(UPDATE_VIEW.NEWS);
-  const cards =
-    view === UPDATE_VIEW.NEWS
-      ? newsCards.slice(0, MAX_UPDATE_CARDS)
-      : eventCards
-          .filter(filterUpcomingEvent)
-          .reverse()
-          .slice(0, MAX_UPDATE_CARDS);
+  const cards = getDisplayCards(view, newsCards, eventCards);
   const updateName = view.toLowerCase();
 
   // Callback fired when toggle button value changes.
@@ -82,14 +70,4 @@ function getToggleButtons(
       value: UPDATE_VIEW.EVENTS,
     },
   ];
-}
-
-/**
- * Returns true if the card has a future date.
- * @param card - Cards
- * @returns true if the card has a future date.
- */
-function filterUpcomingEvent(card: UpdateCard): boolean {
-  if (!card.date) return false;
-  return new Date(card.date) >= new Date();
 }

--- a/components/Home/components/Section/components/SectionUpdates/utils.ts
+++ b/components/Home/components/Section/components/SectionUpdates/utils.ts
@@ -1,23 +1,11 @@
 import { UpdateCard } from "./common/entities";
 import { MAX_UPDATE_CARDS, UPDATE_VIEW } from "./constants";
 
-const PLACEHOLDER_CARD: Record<UPDATE_VIEW, UpdateCard> = {
-  [UPDATE_VIEW.EVENTS]: {
-    link: { label: null, url: "/events" },
-    text: "Browse all AnVIL events.",
-    title: "No upcoming events",
-  },
-  [UPDATE_VIEW.NEWS]: {
-    link: { label: null, url: "/news" },
-    text: "Browse all AnVIL news.",
-    title: "No recent news",
-  },
-};
-
 /**
- * Returns the cards to display in the updates section. When the filter yields
- * no results, a single placeholder card linking to the full archive is
- * returned in its place.
+ * Returns the cards to display in the updates section. News always shows the
+ * most recent items (0–3, no placeholder). Events filter to upcoming items
+ * and fall back to a single placeholder card linking to the events archive
+ * when none are available.
  * @param view - Current update view (news or events).
  * @param newsCards - All news cards.
  * @param eventCards - All event cards.
@@ -28,14 +16,25 @@ export function getDisplayCards(
   newsCards: UpdateCard[],
   eventCards: UpdateCard[]
 ): UpdateCard[] {
-  const cards =
-    view === UPDATE_VIEW.NEWS
-      ? newsCards.slice(0, MAX_UPDATE_CARDS)
-      : eventCards
-          .filter(filterUpcomingEvent)
-          .reverse()
-          .slice(0, MAX_UPDATE_CARDS);
-  if (cards.length === 0) return [PLACEHOLDER_CARD[view]];
+  if (view === UPDATE_VIEW.NEWS) {
+    return newsCards.slice(0, MAX_UPDATE_CARDS);
+  }
+
+  const cards = eventCards
+    .filter(filterUpcomingEvent)
+    .reverse()
+    .slice(0, MAX_UPDATE_CARDS);
+
+  if (cards.length === 0) {
+    return [
+      {
+        link: { label: null, url: "/events" },
+        text: "Browse all AnVIL events.",
+        title: "No upcoming events",
+      },
+    ];
+  }
+
   return cards;
 }
 

--- a/components/Home/components/Section/components/SectionUpdates/utils.ts
+++ b/components/Home/components/Section/components/SectionUpdates/utils.ts
@@ -1,0 +1,50 @@
+import { UpdateCard } from "./common/entities";
+import { MAX_UPDATE_CARDS, UPDATE_VIEW } from "./constants";
+
+const PLACEHOLDER_CARD: Record<UPDATE_VIEW, UpdateCard> = {
+  [UPDATE_VIEW.EVENTS]: {
+    link: { label: null, url: "/events" },
+    text: "Browse all AnVIL events.",
+    title: "No upcoming events",
+  },
+  [UPDATE_VIEW.NEWS]: {
+    link: { label: null, url: "/news" },
+    text: "Browse all AnVIL news.",
+    title: "No recent news",
+  },
+};
+
+/**
+ * Returns the cards to display in the updates section. When the filter yields
+ * no results, a single placeholder card linking to the full archive is
+ * returned in its place.
+ * @param view - Current update view (news or events).
+ * @param newsCards - All news cards.
+ * @param eventCards - All event cards.
+ * @returns Cards to display.
+ */
+export function getDisplayCards(
+  view: UPDATE_VIEW,
+  newsCards: UpdateCard[],
+  eventCards: UpdateCard[]
+): UpdateCard[] {
+  const cards =
+    view === UPDATE_VIEW.NEWS
+      ? newsCards.slice(0, MAX_UPDATE_CARDS)
+      : eventCards
+          .filter(filterUpcomingEvent)
+          .reverse()
+          .slice(0, MAX_UPDATE_CARDS);
+  if (cards.length === 0) return [PLACEHOLDER_CARD[view]];
+  return cards;
+}
+
+/**
+ * Returns true if the card has a future date.
+ * @param card - Card.
+ * @returns true if the card has a future date.
+ */
+function filterUpcomingEvent(card: UpdateCard): boolean {
+  if (!card.date) return false;
+  return new Date(card.date) >= new Date();
+}

--- a/content/constants.ts
+++ b/content/constants.ts
@@ -1,1 +1,3 @@
 export const DATE_FORMAT = "MMMM DD, YYYY";
+
+export const RECENT_CONTENT_MONTHS = 3;

--- a/content/entities.ts
+++ b/content/entities.ts
@@ -38,6 +38,11 @@ export interface FrontmatterEvent extends DefaultFrontmatter {
   formattedSessions?: string[];
   hashtag?: Hashtag;
   location?: string;
+  /**
+   * When true, keeps this event eligible for the home page carousel and
+   * featured section regardless of its date. Use for evergreen items like
+   * recurring conferences or ongoing programs.
+   */
   persistent?: boolean;
   sessions: EventSession[];
   timestamp?: number;
@@ -48,6 +53,11 @@ export interface FrontmatterEvent extends DefaultFrontmatter {
 export interface FrontmatterNews extends DefaultFrontmatter {
   date: string;
   featured?: boolean;
+  /**
+   * When true, keeps this news item eligible for the home page carousel and
+   * featured section regardless of its date. Use for evergreen content like
+   * flagship announcements.
+   */
   persistent?: boolean;
   url: string | null;
 }

--- a/content/entities.ts
+++ b/content/entities.ts
@@ -38,6 +38,7 @@ export interface FrontmatterEvent extends DefaultFrontmatter {
   formattedSessions?: string[];
   hashtag?: Hashtag;
   location?: string;
+  persistent?: boolean;
   sessions: EventSession[];
   timestamp?: number;
   timezone: string;
@@ -47,6 +48,7 @@ export interface FrontmatterEvent extends DefaultFrontmatter {
 export interface FrontmatterNews extends DefaultFrontmatter {
   date: string;
   featured?: boolean;
+  persistent?: boolean;
   url: string | null;
 }
 

--- a/content/utils.ts
+++ b/content/utils.ts
@@ -1,3 +1,4 @@
+import { isAfter, subMonths } from "date-fns";
 import fs from "fs";
 import matter from "gray-matter";
 import moment, { Moment, tz } from "moment-timezone";
@@ -6,6 +7,7 @@ import { default as path, default as pathTool } from "path";
 import { SlugByFilePaths } from "../docs/common/entities";
 import { resolveDocPath } from "../docs/common/generateStaticPaths";
 import { mapSlugByFilePaths } from "../docs/common/utils";
+import { RECENT_CONTENT_MONTHS } from "./constants";
 import {
   EventSession,
   Frontmatter,
@@ -196,4 +198,44 @@ export function isFrontmatterNews(
   frontmatter: Frontmatter
 ): frontmatter is FrontmatterNews {
   return "date" in frontmatter;
+}
+
+/**
+ * Returns true if the persistent field is defined, and true. Persistent items
+ * remain eligible for the carousel and featured section regardless of date.
+ * @param frontmatter - Frontmatter.
+ * @returns true if the persistent field is defined, and true.
+ */
+export function isPersistent(frontmatter: Frontmatter): boolean | undefined {
+  return "persistent" in frontmatter && frontmatter.persistent;
+}
+
+/**
+ * Returns true if an item should remain eligible for the carousel or featured
+ * section: persistent items always pass; otherwise the item must have a date
+ * within the recent-content window.
+ * @param date - Date to test.
+ * @param persistent - Persistent flag.
+ * @returns true if the item is recent or persistent.
+ */
+export function isRecentOrPersistent(
+  date: Date | string | undefined,
+  persistent: boolean | undefined
+): boolean {
+  if (persistent) return true;
+  if (!date) return false;
+  return isWithinRecentWindow(date);
+}
+
+/**
+ * Returns true if the given date is within the recent-content window
+ * (RECENT_CONTENT_MONTHS months before now).
+ * @param date - Date to test.
+ * @returns true if the date is within the recent-content window.
+ */
+export function isWithinRecentWindow(date: Date | string): boolean {
+  const target = date instanceof Date ? date : new Date(date);
+  if (isNaN(target.getTime())) return false;
+  const cutoff = subMonths(new Date(), RECENT_CONTENT_MONTHS);
+  return isAfter(target, cutoff);
 }

--- a/content/utils.ts
+++ b/content/utils.ts
@@ -1,4 +1,4 @@
-import { isAfter, subMonths } from "date-fns";
+import { isAfter, startOfDay, subMonths } from "date-fns";
 import fs from "fs";
 import matter from "gray-matter";
 import moment, { Moment, tz } from "moment-timezone";
@@ -236,6 +236,6 @@ export function isRecentOrPersistent(
 export function isWithinRecentWindow(date: Date | string): boolean {
   const target = date instanceof Date ? date : new Date(date);
   if (isNaN(target.getTime())) return false;
-  const cutoff = subMonths(new Date(), RECENT_CONTENT_MONTHS);
+  const cutoff = startOfDay(subMonths(new Date(), RECENT_CONTENT_MONTHS));
   return isAfter(target, cutoff);
 }

--- a/docs/events/README.md
+++ b/docs/events/README.md
@@ -1,0 +1,44 @@
+# Events content authoring
+
+Event items render in the home page Updates section (Events tab) and in the full events archive at `/events`.
+
+## File path
+
+`docs/events/slug.mdx`
+
+Events live in a flat directory. The session date(s) are in the frontmatter `sessions` array, not in the path.
+
+## Frontmatter
+
+```yaml
+---
+conference: "ACC 2026" # required — conference / event name
+description: "Short summary shown in cards and meta tags."   # required
+title: "Full event title" # required
+timezone: "America/New_York" # required — IANA timezone for sessions
+sessions: # required — one or more session windows
+  - sessionStart: "31 August 2026 2:00 PM"
+    sessionEnd: "31 August 2026 5:30 PM"
+  - sessionStart: "1 September 2026 9:00 AM"
+    sessionEnd: "1 September 2026 6:00 PM"
+eventType: "Conference" # optional — e.g. Conference, Workshop, Webinar
+location: "Cambridge, MA" # optional — physical location or "Online"
+hashtag: "#AnVILCommunity" # optional — social tag (must start with `#`)
+url: "https://..." # optional — registration / event link
+featured: true # optional — eligible for home page Updates section
+persistent: true # optional — see "Visibility" below
+hidden: true # optional — hide from all listings
+---
+```
+
+### Session dates
+
+Use the format `D MMMM YYYY h:mm A` (e.g. `1 September 2026 9:00 AM`) in `sessionStart` and `sessionEnd`. The earliest `sessionStart` determines whether the event counts as "upcoming" on the home page.
+
+## Visibility
+
+The home page Updates section (Events tab) shows only upcoming `featured` events, capped at 3 cards.
+
+The hero carousel uses a 3-month freshness window: dated entries within the last 3 months show by default. Set `persistent: true` to keep an event eligible regardless of date — useful for recurring conferences.
+
+Use `hidden: true` to suppress an event from all listings.

--- a/docs/news/README.md
+++ b/docs/news/README.md
@@ -1,0 +1,31 @@
+# News content authoring
+
+News items render in the home page Updates section and in the full news archive at `/news`.
+
+## File path
+
+`docs/news/YYYY/MM/DD/slug.mdx`
+
+The directory path encodes the publication date. The URL slug is derived from the file name.
+
+## Frontmatter
+
+```yaml
+---
+date: "YYYY-MM-DD" # required — publication date
+description: "Short summary shown in cards and meta tags."   # required
+title: "Headline" # required
+featured: true # optional — eligible for home page Updates section
+persistent: true # optional — see "Visibility" below
+hidden: true # optional — hide from all listings
+url: "https://..." # optional — external link (omit or use null otherwise)
+---
+```
+
+## Visibility
+
+By default, the home page Updates section (and the hero carousel) only show items with a `date` within the last 3 months — older items fall off automatically.
+
+To keep an item visible past that window — e.g. a flagship announcement, an ongoing program, an evergreen paper — set `persistent: true`.
+
+The full news archive at `/news` shows everything regardless of date or `persistent`. Use `hidden: true` to suppress an item from all listings.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import { JSX } from "react";
+import { DIR_NAME as EVENTS_DIR_NAME } from "../components/Events/common/constants";
 import { Footer } from "../components/Home/components/Layout/components/Footer/footer.styles";
 import { Main } from "../components/Home/components/Layout/components/Main/main";
 import { buildAnalysisPortalCards } from "../components/Home/components/Section/components/SectionAnalysisPortals/common/utils";
@@ -8,8 +9,13 @@ import { CARDS as DATASET_CARDS } from "../components/Home/components/Section/co
 import { buildToolsAndWorkflowsCards } from "../components/Home/components/Section/components/SectionExplore/common/utils";
 import { buildCarouselCards } from "../components/Home/components/Section/components/SectionHero/common/utils";
 import { buildPublicationSectionCards } from "../components/Home/components/Section/components/SectionPublications/common/utils";
-import { buildUpdateSectionCards } from "../components/Home/components/Section/components/SectionUpdates/common/utils";
+import {
+  buildUpdateSectionCards,
+  filterEventFrontmatter,
+  filterNewsFrontmatter,
+} from "../components/Home/components/Section/components/SectionUpdates/common/utils";
 import { CARDS as WORKSPACE_CARDS } from "../components/Home/components/Section/components/SectionWorkspaces/common/content";
+import { DIR_NAME as NEWS_DIR_NAME } from "../components/News/common/constants";
 import { config } from "../config/config";
 import { SectionsData, SectionsDataProvider } from "../providers/sectionsData";
 import { HomeView } from "../views/HomeView/homeView";
@@ -21,8 +27,14 @@ export const getStaticProps: GetStaticProps<SectionsData> = async () => {
   const cloudCards = CLOUD_CARDS;
   const datasetCards = DATASET_CARDS;
   const toolsAndWorkflowsCards = buildToolsAndWorkflowsCards(browserURL);
-  const eventCards = buildUpdateSectionCards("events");
-  const newsCards = buildUpdateSectionCards("news");
+  const eventCards = buildUpdateSectionCards(
+    EVENTS_DIR_NAME,
+    filterEventFrontmatter
+  );
+  const newsCards = buildUpdateSectionCards(
+    NEWS_DIR_NAME,
+    filterNewsFrontmatter
+  );
   const publicationCards = buildPublicationSectionCards();
   const workspaceCards = WORKSPACE_CARDS;
   return {


### PR DESCRIPTION
## Summary

Closes #3961.

Limit the home page **carousel** and the **Updates → Events** tab to content with a publication date within the last 3 months. Adds an opt-in `persistent` frontmatter flag that keeps an item eligible regardless of date — for evergreen items like flagship papers, ongoing programs, and recurring events. **News is not subject to the recent-content window** — the Updates → News tab always shows the 3 most recent featured items regardless of age.

- New `RECENT_CONTENT_MONTHS = 3` constant in `content/constants.ts`.
- `persistent?: boolean` added to `FrontmatterNews` and `FrontmatterEvent`.
- New helpers in `content/utils.ts`: `isPersistent`, `isRecentOrPersistent(date, persistent)`, `isWithinRecentWindow(date)`.
- Updates section: filter split into `filterEventFrontmatter` (featured + !hidden + `isRecentOrPersistent`) and `filterNewsFrontmatter` (featured + !hidden + has date — no recency rule). `buildUpdateSectionCards(dirName, filterFn)` takes the filter as an arg; callers in `pages/index.tsx` pass the right one (using the existing `DIR_NAME` constants from `components/Events/common/constants.ts` and `components/News/common/constants.ts`).
- Hero carousel: extracted the previously-inline list to a `CAROUSEL_CARDS` const with optional `date` / `persistent` per entry; `buildCarouselCards` filters via the same rule. 4 existing entries annotated with `date`, 10 with `persistent: true` (papers, AnVIL Shorts, video tutorials, etc.).
- `SectionCard` interface extended with optional `date?: string` and `persistent?: boolean`.
- New `SectionUpdates/utils.ts` lifts card selection out of `sectionUpdates.tsx`. **Events** falls back to a placeholder card linking to `/events` when no upcoming events exist; **News** has no placeholder (always shows 0–3 most recent items).
- New `SectionUpdates/constants.ts` extracts `UPDATE_VIEW` and `MAX_UPDATE_CARDS` (avoids a circular import between component and its utils).

## Test plan

- [x] Home page Updates section: dated news inside 3 months renders; older items disappear unless marked `persistent: true`.
- [x] Toggle Events tab: behavior unchanged for upcoming events.
- [x] When no news passes the filter, a "No recent news" placeholder card renders, linking to `/news`. Same for events → `/events`.
- [x] Hero carousel: only entries with a recent `date` or `persistent: true` are shown. Verify GREGoR paper, AnVIL Shorts, etc. still appear (they're `persistent`).
- [x] Carousel entries with dated URLs (AWS partnership, March 2026 release) drop off three months after their date.
- [x] Build (\`npm run build-dev:anvil-portal\`) succeeds.
- [x] News tab now shows the 3 most recent featured news items regardless of age (recency rule removed for news).
- [x] News tab no longer renders a placeholder card; only events fall back to a placeholder when empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)