### PR TITLE
chore: add robots.txt for bot crawl protection

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,43 @@
+# Search engines
+User-agent: *
+Allow: /
+
+# SEO scrapers
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+# AI training crawlers
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+Sitemap: https://anvilproject.org/sitemap.xml


### PR DESCRIPTION
## Ticket
Closes #3964

## Summary
- Add `robots.txt` to block SEO scrapers (AhrefsBot, SemrushBot, etc.) and AI training crawlers (GPTBot, Google-Extended, CCBot, etc.)
- Allow standard search engine indexing
- Include sitemap reference

## Test plan
- [ ] Verify `robots.txt` is served at `/robots.txt` after deploy
- [ ] Confirm search engines can still crawl the site normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)