### PR TITLE
fix: slack link unfurls on anvilproject.org missing og image (#3968)

### DIFF
--- a/components/common/OgMeta/constants.ts
+++ b/components/common/OgMeta/constants.ts
@@ -1,2 +1,4 @@
 export const DEFAULT_DESCRIPTION =
   "AnVIL is NHGRI's Genomic Data Science Analysis, Visualization, and Informatics Lab-Space.";
+
+export const TWITTER_HANDLE = "@useAnVIL";

--- a/components/common/OgMeta/ogMeta.tsx
+++ b/components/common/OgMeta/ogMeta.tsx
@@ -1,6 +1,7 @@
 import NextHead from "next/head";
 import { useRouter } from "next/router";
 import { JSX } from "react";
+import { TWITTER_HANDLE } from "./constants";
 import type { OgMetaProps } from "./types";
 
 /**
@@ -64,7 +65,13 @@ export const OgMeta = ({
       <meta key="og:type" content="website" property="og:type" />
       <meta key="og:url" content={url} property="og:url" />
       <meta key="twitter:card" content="summary" name="twitter:card" />
+      <meta
+        key="twitter:creator"
+        content={TWITTER_HANDLE}
+        name="twitter:creator"
+      />
       <meta key="twitter:image" content={image} name="twitter:image" />
+      <meta key="twitter:site" content={TWITTER_HANDLE} name="twitter:site" />
     </NextHead>
   );
 };


### PR DESCRIPTION
## Summary

Adds `twitter:site` and `twitter:creator` meta tags (both `@useAnVIL`) to `OgMeta` so Slack's unfurl pipeline renders the OG image. Without these tags, Slack falls back to a text-only card even though the OG image is correctly served.

Closes #3968.

## Why

Compared anvil-portal against NCPI Dataset Catalog (which unfurls correctly in Slack). Both use a 512×512 RGBA PNG, `twitter:card: summary`, and otherwise-identical OG metadata. The only structural difference was that NCPI emits `twitter:site` / `twitter:creator` and anvil-portal didn't. Adding them is the change.

Ruled out before landing this:
- Slack cache (three unique `?v=*` URLs all came back imageless — fresh scrapes)
- Image-size spec (NCPI uses the same 512×512 and works; the "1200×630 minimum" theory was wrong)
- Image-reachability (HTTP 200, valid PNG, opengraph.xyz fetches and renders it)

## Test plan

- [x] `npm run check-format`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build-dev:anvil-portal` — exported `out/index.html` contains both new tags with `content="@useAnVIL"`
- [ ] After deploy: post `https://anvilproject.org/?v=cachebust` in Slack and confirm the OG icon renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)