### PR TITLE
content: update seqr homepage link to new news article

### DIFF
--- a/components/Home/components/Section/components/SectionAnalysisPortals/common/utils.ts
+++ b/components/Home/components/Section/components/SectionAnalysisPortals/common/utils.ts
@@ -130,7 +130,7 @@ export function buildAnalysisPortalCards(browserURL: string): SectionCard[] {
         {
           label: ACTION_LABEL.LEARN_MORE,
           target: ANCHOR_TARGET.SELF,
-          url: "/news/2021/03/10/announcing-seqr-in-anvil/",
+          url: "/news/2026/06/11/seqr-about-on-anvil/",
         },
       ],
       media: {


### PR DESCRIPTION
## Ticket
Closes #3985

## Summary
- Update the seqr "Learn More" link on the homepage to point to the new seqr news article (`/news/2026/06/11/seqr-about-on-anvil/`) instead of the old one (`/news/2021/03/10/announcing-seqr-in-anvil/`)

## Test plan
- [ ] Verify the "Learn More" link on the homepage seqr card navigates to the new article
- [ ] Verify the new article page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)