### PR TITLE
fix: remove dead galaxy chat link from help page #3988

### DIFF
--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -28,5 +28,5 @@ Refer to the following table for help links for AnVIL platform components and to
 |:-------------|:--------------------------------------------------------------------------------------------------------------------------|
 | Bioconductor | [Help Hub](http://bioconductor.org/help/), [Help Forum](https://support.bioconductor.org/)                                |
 | Dockstore    | [Help Forum](https://discuss.dockstore.org/)                                                                              |
-| Galaxy       | [Help Forum](https://help.galaxyproject.org/), [Chat](https://gitter.im/galaxyproject)                                    |
+| Galaxy       | [Help Forum](https://help.galaxyproject.org/)                                                                              |
 | Terra        | [Support Hub](https://support.terra.bio/hc/en-us), [Community Forum](https://support.terra.bio/hc/en-us/community/topics) |


### PR DESCRIPTION
## Ticket
Closes #3988

## Summary
- Remove dead Gitter chat link (`https://gitter.im/galaxyproject`) from the Galaxy row on the help page — returns 404 since Gitter was shut down

## Test plan
- [ ] Verify the help page renders correctly at `/help`
- [ ] Confirm the Galaxy row shows only the Help Forum link

🤖 Generated with [Claude Code](https://claude.com/claude-code)