### PR TITLE
ci: group dependabot minor/patch updates into monthly PRs #3998

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,31 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
+    # Check the npm registry for updates monthly, grouping minor and patch
+    # bumps into a single PR; major bumps still open individual PRs
     schedule:
-      interval: "daily"
+      interval: "monthly"
     assignees:
       - "noopdog"
-    open-pull-requests-limit: 50
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+  # Enable version updates for the analytics Python scripts
+  - package-ecosystem: "pip"
+    directory: "/analytics"
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "noopdog"
+  # Enable version updates for the disease-codes Python scripts
+  - package-ecosystem: "pip"
+    directory: "/scripts/disease-codes"
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "noopdog"


### PR DESCRIPTION
Closes #3998

## Changes to `.github/dependabot.yml`

- **npm**: daily → monthly schedule; minor and patch bumps are grouped into a single PR (majors still open individually); `open-pull-requests-limit` lowered from 50 to 5.
- **pip**: new monthly entries for `/analytics` and `/scripts/disease-codes`, so their pinned requirements (currently `Jinja2==3.1.4` and `tornado==6.4.1`, both with open security PRs #3477/#3407) get regular version updates rather than only ad-hoc security PRs.

## Context

41 stale Dependabot PRs (September 2024–January 2025) were closed as superseded on 2026-07-10; Dependabot had auto-paused from inactivity, which is why they lingered. This config keeps it active while collapsing routine updates to roughly one PR per month per ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)