### PR TITLE
ci: group dependabot pip updates into a single PR per directory #3998

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,17 +18,27 @@ updates:
         update-types:
           - "minor"
           - "patch"
-  # Enable version updates for the analytics Python scripts
+  # Enable version updates for the analytics Python scripts, grouping all
+  # bumps into a single PR per run
   - package-ecosystem: "pip"
     directory: "/analytics"
     schedule:
       interval: "monthly"
     assignees:
       - "noopdog"
-  # Enable version updates for the disease-codes Python scripts
+    groups:
+      all-updates:
+        patterns:
+          - "*"
+  # Enable version updates for the disease-codes Python scripts, grouping all
+  # bumps into a single PR per run
   - package-ecosystem: "pip"
     directory: "/scripts/disease-codes"
     schedule:
       interval: "monthly"
     assignees:
       - "noopdog"
+    groups:
+      all-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
Follow-up to #3999 / #3998.

The pip ecosystem entries added in #3999 had no `groups`, so Dependabot's first pip run (2026-07-10) opened one PR per package (#4008–#4015) and immediately hit the 5-PR limit for `/analytics`. This adds an `all-updates` group to both pip entries so each Python directory gets a single grouped PR per monthly run.

A separate PR will refresh `analytics/requirements.txt` and `scripts/disease-codes/requirements.txt` to current versions, which should close the open per-package pip PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)