### PR TITLE
ci: fix dependabot assignee username casing #3998

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "monthly"
     assignees:
-      - "noopdog"
+      - "NoopDog"
     open-pull-requests-limit: 5
     groups:
       minor-and-patch:
@@ -25,7 +25,7 @@ updates:
     schedule:
       interval: "monthly"
     assignees:
-      - "noopdog"
+      - "NoopDog"
     groups:
       all-updates:
         patterns:
@@ -37,7 +37,7 @@ updates:
     schedule:
       interval: "monthly"
     assignees:
-      - "noopdog"
+      - "NoopDog"
     groups:
       all-updates:
         patterns:


### PR DESCRIPTION
Dependabot has been erroring on its PRs with:

> The following users could not be added as assignees: noopdog. Either the username does not exist or it does not have the correct permissions to be added as an assignee.

The account exists (canonical login `NoopDog`, repo admin, on the assignable list — verified via the API), but Dependabot validates `assignees` entries with an exact case-sensitive match against the assignable-user list, unlike the GitHub API itself, which is case-insensitive. The lowercase spelling predates the recent config changes; it only surfaced now that Dependabot is active again.

Fixes the casing in all three ecosystem entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)