### PR TITLE
ci: upgrade release-please-action from v4 to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
Closes #4035

Upgrades `googleapis/release-please-action` from the `v4` tag to v5.0.0, pinned by commit SHA (the same pin clevercanary/cc-claude-tools already uses). The only breaking change in v5.0.0 is the move to the Node 24 runtime, which GitHub-hosted runners already support, so no configuration changes are needed.

## Test plan

The workflow only triggers on push to `main` (plus manual dispatch), so it cannot run on this PR branch. Verification happens in two steps after merge:

1. The merge commit itself triggers the workflow. Confirm the `release-please` run on `main` completes successfully and force-updates the existing release PR (`release-please--branches--main--components--the-anvil`) without errors.
2. Alternatively or additionally, trigger the workflow manually via `workflow_dispatch` and confirm a green run.

Pre-merge checks already done: YAML parses, and the pinned SHA `45996ed1f6d02564a971a2fa1b5860e934307cf7` was verified against the upstream `v5.0.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)