### PR TITLE
ci: pin github actions by commit sha at current versions

### DIFF
--- a/.github/workflows/deploy-analytics.yml
+++ b/.github/workflows/deploy-analytics.yml
@@ -25,16 +25,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "analytics/anvil-analytics-portal/sheets/site"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -22,14 +22,14 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
           fetch-depth: 1
           fetch-tags: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.13.0"
 
@@ -42,7 +42,7 @@ jobs:
         run: npm run build-dev:anvil-portal
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.DEV_AWS_ACCOUNT_ID }}:role/${{ secrets.DEV_AWS_ROLE_NAME }}
           role-session-name: ${{ secrets.DEV_ROLE_SESSION_NAME }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -5,8 +5,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.13.0"
 


### PR DESCRIPTION
Closes #4038

Upgrades every action reference to its current version and converts all tag pins to commit SHA pins with version comments, per the table in #4038. SHAs were resolved and verified against each upstream repository's tags.

| Workflow | Action | Before | After |
|---|---|---|---|
| deploy-analytics.yml | actions/checkout | v4 | v7.0.0 |
| deploy-analytics.yml | actions/configure-pages | v5 | v6.0.0 |
| deploy-analytics.yml | actions/upload-pages-artifact | v3 | v5.0.0 |
| deploy-analytics.yml | actions/deploy-pages | v4 | v5.0.0 |
| dev-deploy.yml | actions/checkout | v3 | v7.0.0 |
| dev-deploy.yml | actions/setup-node | v3 | v7.0.0 |
| dev-deploy.yml | aws-actions/configure-aws-credentials | v4 | v6.2.2 |
| test-build.yml | actions/checkout | v2 | v7.0.0 |
| test-build.yml | actions/setup-node | v2 | v7.0.0 |

This is also the prerequisite for the explicit Actions allowlist in #4039, whose entries match these SHAs.

## Test plan

- test-build triggers on pull requests, so it validates checkout and setup-node at v7 on this PR itself.
- deploy-analytics and dev-deploy only run on their own triggers; after merge, confirm each completes a green run (natural trigger or manual dispatch) with no Node deprecation annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)