### PR TITLE
Adding abstract extension date to ACC2026 website

### DIFF
--- a/docs/events/anvil2026-community-conference.mdx
+++ b/docs/events/anvil2026-community-conference.mdx
@@ -76,7 +76,7 @@ Get onto the AnVIL platform at our workshops where you'll learn the basics of cl
 #### Abstract Submission
 
 - Opens May 1, 2026
-- Closes July 15, 2026 for oral presentations
+- **Abstract submission deadline extended until July 26th at midnight!**
 - Decisions for oral presentations returned August 1, 2026
 - Closes August 10, 2026 for poster presentations
 - Decisions for poster presentations returned August 11, 2026


### PR DESCRIPTION
Update anvil2026-community-conference.mdx

Updating the page to include the abstract exetension under "Key Dates".