### PR TITLE
build: read node version from .nvmrc in deploy scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,4 +98,4 @@ Uses conventional commits (enforced by commitlint):
 
 ## Node Version
 
-Node.js 22.12.0 is required (specified in `package.json` engines).
+The required Node.js version is specified in `.nvmrc` and `package.json` engines.

--- a/cc-anvilproject.consortia.dev-deploy.sh
+++ b/cc-anvilproject.consortia.dev-deploy.sh
@@ -6,7 +6,7 @@ rm -rf ./out
 echo \"Deleting ./build/\"
 rm -rf ./build
 
-n 22.12.0
+n $(cat .nvmrc)
 npm ci
 
 mkdir -p build

--- a/cgl-anvilproject.consortia.prod-deploy.sh
+++ b/cgl-anvilproject.consortia.prod-deploy.sh
@@ -6,7 +6,7 @@ rm -rf ./out
 echo \"Deleting ./build/\"
 rm -rf ./build
 
-n 22.12.0
+n $(cat .nvmrc)
 npm ci
 
 mkdir -p build


### PR DESCRIPTION
Closes #4044

## What changed

- `cc-anvilproject.consortia.dev-deploy.sh` and `cgl-anvilproject.consortia.prod-deploy.sh` now run `n $(cat .nvmrc)` instead of the hardcoded `n 22.12.0`.
- The "Node Version" section of `CLAUDE.md` no longer states a version number; it points to `.nvmrc` and `package.json` engines as the source of truth.

## Why

The deploy scripts pinned Node 22.12.0 while `.nvmrc` and `package.json` engines declare 22.13.0, so deploys were building with an older Node than the project declares. Reading `.nvmrc` gives a single source of truth so the scripts can't drift again. CLAUDE.md had the same stale 22.12.0 reference.

## Assumptions I made

- The deploy scripts are always run manually from the repo root (all their other paths — `./out`, `./build`, `npm ci` — already assume this), so the relative `cat .nvmrc` is safe. A repo-wide search confirmed nothing in CI or package.json invokes these scripts.
- `n $(cat .nvmrc)` was chosen over `n auto` for explicitness; both resolve from `.nvmrc`.
- CI workflows (`dev-deploy.yml`, `test-build.yml`) hardcode `node-version: "22.13.0"`, which currently matches `.nvmrc`; switching them to `node-version-file` was left out of scope for this issue.
- CLAUDE.md intentionally omits the version number (per review feedback) so it can't go stale.

## How to verify

The issue's definition of done: both scripts stop hardcoding the Node version and read it from `.nvmrc`, and the stale CLAUDE.md reference is fixed.

1. From the repo root, run `echo "n $(cat .nvmrc)"` — it should print `n 22.13.0`, confirming the substitution resolves to the version declared in `.nvmrc` (matching `package.json` engines).
2. Run `bash -n cc-anvilproject.consortia.dev-deploy.sh && bash -n cgl-anvilproject.consortia.prod-deploy.sh` — both pass syntax check.
3. Grep for the old pin: `grep -rn "22.12.0" *.sh CLAUDE.md` — no matches remain.
4. Optionally run the dev deploy script as usual and confirm `node --version` reports `v22.13.0` after the `n` line executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)