### PR TITLE
content: add anvil101 virtual workshop (#4043)

### DIFF
--- a/docs/events/anvil2026-101-virtual-workshop.mdx
+++ b/docs/events/anvil2026-101-virtual-workshop.mdx
@@ -1,0 +1,50 @@
+---
+conference: "AnVIL 101"
+description: "Learn the basics of AnVIL"
+eventType: "Virtual Workshop"
+featured: true
+location: "Virtual"
+sessions:
+  [
+    {
+      sessionStart: "29 July 2026 1:00 PM",
+      sessionEnd: "29 July 2026 3:00 PM",
+    },
+  ]
+timezone: "America/New_York"
+title: "AnVIL 101 Virtual Workshop"
+---
+
+<EventsHero {...frontmatter} />
+
+Are you interested in learning about AnVIL and running your first analysis in the cloud? Join us for the AnVIL 101 Virtual Workshop on Wednesday, July 29, 2026 from 1:00-3:00 PM ET.
+
+This virtual workshop is designed for anyone who wants an introduction to the AnVIL platform, including researchers working with controlled-access human genomics data, new AnVIL users, and anyone interested in learning how cloud-based genomic analysis works on AnVIL.
+
+[REGISTER today!](https://bit.ly/anvil2026-virtual101)
+
+## What to Expect
+
+The workshop will include an overview of AnVIL, a live platform demo, and a guided hands-on analysis to help participants run their first job in the cloud.
+
+### INTRO TO ANVIL: Learn the Basics
+
+Learn what AnVIL is: the NHGRI Analysis, Visualization, and Informatics Lab-space, and how it enables cloud computing for human genomics research and beyond.
+
+### LIVE DEMO: See the Platform in Action
+
+Watch a live walkthrough of the platform and learn about available analysis tools, including Galaxy, Bioconductor, Jupyter, and WDL workflows.
+
+### HANDS-ON ANALYSIS: Run Your First Job in the Cloud
+
+Try AnVIL for yourself with a guided hands-on analysis and gain practical experience working in a cloud-based research environment.
+
+### New to AnVIL?
+
+This workshop is a great starting point for anyone who wants to build familiarity with AnVIL, whether you are exploring the platform for the first time or preparing to engage more deeply with the AnVIL community.
+
+## Event Details
+
+- How to register: Register using [bit.ly/anvil2026-virtual101](https://bit.ly/anvil2026-virtual101).
+- Costs: Free
+- Contact Info: Let us know of any questions at the [AnVIL Support Forum]({anvilHelpURL}).


### PR DESCRIPTION
## Summary

Adds the AnVIL 101 Virtual Workshop event (July 29, 2026, 1–3 PM ET, Virtual) to the events archive.

- New content file `docs/events/anvil2026-101-virtual-workshop.mdx` following the existing event conventions (`EventsHero`, frontmatter, Event Details block).
- `featured: true` so it's eligible for the home page Updates section.
- Registration link, cost, and AnVIL Support Forum contact included.

Closes #4043

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2560" height="1197" alt="image" src="https://github.com/user-attachments/assets/11fd2e40-4a28-4b7d-be29-67fca148b781" />
