### PR TITLE
feat: update pre-release notes to the card-based release-notes format (#4062)

### DIFF
--- a/components/Releases/components/UpcomingChanges/upcomingChanges.tsx
+++ b/components/Releases/components/UpcomingChanges/upcomingChanges.tsx
@@ -1,6 +1,7 @@
 import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/RoundedPaper/roundedPaper";
 import { MarkdownRenderer } from "@databiosphere/findable-ui/lib/components/MarkdownRenderer/markdownRenderer";
-import { CardContent, CardHeader, Stack } from "@mui/material";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { CardContent, CardHeader, Stack, Typography } from "@mui/material";
 import { JSX } from "react";
 import { ReleaseData } from "../../data/types";
 import { StyledCard } from "../Card/card.styles";
@@ -21,7 +22,16 @@ export const UpcomingChanges = ({
             title={<Title {...release} />}
           />
           <CardContent>
-            <MarkdownRenderer value={description} />
+            <Stack spacing={2} useFlexGap>
+              <Typography
+                color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+                component="div"
+                variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}
+              >
+                Upcoming Changes
+              </Typography>
+              <MarkdownRenderer value={description} />
+            </Stack>
           </CardContent>
         </StyledCard>
       ))}

--- a/components/Releases/components/UpcomingChanges/upcomingChanges.tsx
+++ b/components/Releases/components/UpcomingChanges/upcomingChanges.tsx
@@ -1,0 +1,30 @@
+import { RoundedPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/RoundedPaper/roundedPaper";
+import { MarkdownRenderer } from "@databiosphere/findable-ui/lib/components/MarkdownRenderer/markdownRenderer";
+import { CardContent, CardHeader, Stack } from "@mui/material";
+import { JSX } from "react";
+import { ReleaseData } from "../../data/types";
+import { StyledCard } from "../Card/card.styles";
+import { Subheader } from "../Card/components/Subheader/subheader";
+import { Title } from "../Card/components/Title/title";
+
+export const UpcomingChanges = ({
+  upcomingChanges,
+}: ReleaseData): JSX.Element | null => {
+  if (!upcomingChanges || upcomingChanges.length === 0) return null;
+  return (
+    <Stack spacing={4} useFlexGap>
+      {upcomingChanges.map(({ description, ...release }) => (
+        <StyledCard key={release.studyName} component={RoundedPaper}>
+          <CardHeader
+            disableTypography
+            subheader={<Subheader {...release} />}
+            title={<Title {...release} />}
+          />
+          <CardContent>
+            <MarkdownRenderer value={description} />
+          </CardContent>
+        </StyledCard>
+      ))}
+    </Stack>
+  );
+};

--- a/components/Releases/data/constants.ts
+++ b/components/Releases/data/constants.ts
@@ -4,4 +4,5 @@ export const RELEASE_DATA_TO_FILE_MAP: Record<keyof ReleaseData, string> = {
   dataAdditions: "data-additions",
   dataModifications: "data-modifications",
   enhancements: "enhancements",
+  upcomingChanges: "upcoming-changes",
 };

--- a/components/Releases/data/types.ts
+++ b/components/Releases/data/types.ts
@@ -29,4 +29,7 @@ export interface ReleaseData {
   dataAdditions?: DataAddition[];
   dataModifications?: DataModification[];
   enhancements?: Enhancement[];
+  upcomingChanges?: UpcomingChange[];
 }
+
+export type UpcomingChange = BaseReleaseData;

--- a/components/Releases/mdx/constants.ts
+++ b/components/Releases/mdx/constants.ts
@@ -3,6 +3,7 @@ import { Link } from "../../common/Link/link";
 import { DataAdditions } from "../components/DataAdditions/dataAdditions";
 import { DataModifications } from "../components/DataModifications/dataModifications";
 import { Enhancements } from "../components/Enhancements/enhancements";
+import { UpcomingChanges } from "../components/UpcomingChanges/upcomingChanges";
 
 export const MDX_COMPONENTS = {
   AnchorLink: C.AnchorLink,
@@ -11,5 +12,6 @@ export const MDX_COMPONENTS = {
   DataModifications,
   Enhancements,
   Figure: C.Figure,
+  UpcomingChanges,
   a: Link,
 };

--- a/docs/releases/2026/05/release-notes.mdx
+++ b/docs/releases/2026/05/release-notes.mdx
@@ -13,6 +13,4 @@ title: "May 2026 Release - Pre-Release Notes"
 
 We're writing to inform you of upcoming changes to the following study in AnVIL. These changes will take effect as early as the **first week of April 2026**.
 
-| Study Name | phsID | DULs | Upcoming Changes |
-|:-----------|:------|:-----|:-----------------|
-| [Impact of Genomic Variation on Function (IGVF) Consortium](https://igvf.org/) | phs003472.v1.p1 | Unrestricted, Mouse | Two files in the current dataset ([Explorer](https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs003472%22%5D%7D%5D)/[Data Library](https://duos.org/studies/191)) were found to have errors and will be replaced in the next data release.<br/><br/>Please reach out to [anvil-data@broadinstitute.org](mailto:anvil-data@broadinstitute.org) if more information is needed. |
+<UpcomingChanges {...releaseData} />

--- a/docs/releases/2026/05/upcoming-changes.json
+++ b/docs/releases/2026/05/upcoming-changes.json
@@ -1,0 +1,9 @@
+[
+  {
+    "description": "Two files in the current dataset ([Explorer](https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs003472%22%5D%7D%5D)/[Data Library](https://duos.org/studies/191)) were found to have errors and will be replaced in the next data release.\n\nPlease reach out to [anvil-data@broadinstitute.org](mailto:anvil-data@broadinstitute.org) if more information is needed.",
+    "duls": ["Unrestricted", "Mouse"],
+    "phsId": "phs003472.v1.p1",
+    "studyName": "Impact of Genomic Variation on Function (IGVF) Consortium",
+    "studyUrl": "https://igvf.org/"
+  }
+]

--- a/docs/releases/2026/08/release-notes.mdx
+++ b/docs/releases/2026/08/release-notes.mdx
@@ -13,6 +13,4 @@ title: "August 2026 Release - Pre-Release Notes"
 
 We're writing to inform you of upcoming changes to the following study in AnVIL. These changes will take effect as early as the **first week of August 2026**.
 
-| Study Name | phsID | DULs | Upcoming Changes |
-|:-----------|:------|:-----|:-----------------|
-| [Common Fund (CF) Genotype-Tissue Expression Project (GTEx)](https://www.gtexportal.org/home/aboutAdultGtex) | phs000424 | Unrestricted | [**AnVIL_GTEx_public_data**](https://anvil.terra.bio/#workspaces/anvil-datastorage/AnVIL_GTEx_public_data) will be taken offline the weeks of **August 3 through August 14** for data updates and re-organization. The release notes will be updated with these changes. We recommend users do not schedule running analyses on this dataset over this time frame.<br/><br/>Please reach out to [anvil-data@broadinstitute.org](mailto:anvil-data@broadinstitute.org) if more information is needed. |
+<UpcomingChanges {...releaseData} />

--- a/docs/releases/2026/08/upcoming-changes.json
+++ b/docs/releases/2026/08/upcoming-changes.json
@@ -1,0 +1,9 @@
+[
+  {
+    "description": "[**AnVIL_GTEx_public_data**](https://anvil.terra.bio/#workspaces/anvil-datastorage/AnVIL_GTEx_public_data) will be taken offline the weeks of **August 3 through August 14** for data updates and re-organization. The release notes will be updated with these changes. We recommend users do not schedule running analyses on this dataset over this time frame.\n\nPlease reach out to [anvil-data@broadinstitute.org](mailto:anvil-data@broadinstitute.org) if more information is needed.",
+    "duls": ["Unrestricted"],
+    "phsId": "phs000424",
+    "studyName": "Common Fund (CF) Genotype-Tissue Expression Project (GTEx)",
+    "studyUrl": "https://www.gtexportal.org/home/aboutAdultGtex"
+  }
+]


### PR DESCRIPTION
## Summary

Closes #4062

Replaces the wide 4-column `Study Name · phsID · DULs · Upcoming Changes` table on the pre-release notes pages with the per-study card format already used by the March 2026 release notes, per the mock on [clevercanary/cc-design#320](https://github.com/clevercanary/cc-design/issues/320).

Each study is now its own card: study name as a linked heading, `phsID · DUL` as a compact meta line, and the change details as prose that can run as long as it needs to.

## Changes

| File | Change |
| --- | --- |
| `components/Releases/components/UpcomingChanges/upcomingChanges.tsx` | New component, reusing the existing `StyledCard`, `Title`, `Subheader` and `MarkdownRenderer` primitives |
| `components/Releases/data/types.ts` | Adds `UpcomingChange` and `ReleaseData.upcomingChanges` |
| `components/Releases/data/constants.ts` | Maps `upcomingChanges` → `upcoming-changes.json` |
| `components/Releases/mdx/constants.ts` | Registers `UpcomingChanges` for MDX |
| `docs/releases/2026/{05,08}/upcoming-changes.json` | New — content lifted verbatim from the tables |
| `docs/releases/2026/{05,08}/release-notes.mdx` | Table → `<UpcomingChanges {...releaseData} />` |

Future pre-release notes follow the same pattern: add an `upcoming-changes.json` beside the MDX file and drop in the one-line component tag.

## Screenshots

<!-- Desktop screenshots to be attached -->

## Verification

Measured on the built output (`npm run build-dev:anvil-portal`, served from `out/`) at a 555px viewport:

- `document.documentElement.scrollWidth` === `clientWidth` (555 / 555) — no horizontal scroll
- zero elements overflowing the right edge of `main`
- zero `<table>` elements remaining on either page
- card reflows to a single column with text wrapping

Also passing: `tsc --noEmit`, `npm run lint` (only the pre-existing `sonarjs/todo-tag` warning in `site-config/common/constants.ts`), `npm run check-format`, and a full production build.

## Notes for review

- **Followed the mock over the issue text.** The issue described an "Upcoming changes" labelled prose block; the Figma mock on cc-design#320 has no such label — meta line straight into prose, matching the March cards. Went with the mock since visual consistency with the release notes is the stated goal. Trivial to add the label if preferred.
- **Two older *news* pages still use the 4-column table** — `docs/news/2025/09/30/november-2025-pre-release-announcement.mdx` and `docs/news/2026/01/06/february-2026-pre-release-announcement.mdx`. They sit outside the issue's scope and on the news route, which doesn't register the Releases MDX components. Left as-is; converting them would mean adding `UpcomingChanges` to the news `MDX_COMPONENTS`.
- **No tests added.** The repo has no test harness (no `test` script, no Playwright config), and the only logic here is the empty-array guard.

<img width="1723" height="851" alt="image" src="https://github.com/user-attachments/assets/8b6b1acf-f05d-48f2-8c08-a1069d63b3b6" />

<img width="1724" height="905" alt="image" src="https://github.com/user-attachments/assets/0b249d5a-396c-4fd0-94ae-694f50f515f6" />

