### PR TITLE
content: add anvil release notes for july 2026 (#4061)

### DIFF
--- a/components/Releases/components/Card/components/Subheader/constants.ts
+++ b/components/Releases/components/Card/components/Subheader/constants.ts
@@ -1,9 +1,0 @@
-import { StackProps } from "@mui/material";
-
-export const STACK_PROPS: StackProps = {
-  columnGap: 2,
-  direction: "row",
-  flexWrap: "wrap",
-  rowGap: 1,
-  useFlexGap: true,
-};

--- a/components/Releases/components/Card/components/Subheader/subheader.styles.ts
+++ b/components/Releases/components/Card/components/Subheader/subheader.styles.ts
@@ -1,9 +1,19 @@
 import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font";
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import styled from "@emotion/styled";
-import { Stack } from "@mui/material";
+import { Box } from "@mui/material";
 
-export const StyledStack = styled(Stack)`
+export const StyledBox = styled(Box)`
   color: ${PALETTE.INK_LIGHT};
   font: ${FONT.BODY_SMALL_400_2_LINES};
+`;
+
+export const StyledDot = styled.span`
+  background-color: ${PALETTE.INK_LIGHT};
+  border-radius: 50%;
+  display: inline-block;
+  height: 4px;
+  margin: 0 8px;
+  vertical-align: 0.21em; /* cap-height midpoint */
+  width: 4px;
 `;

--- a/components/Releases/components/Card/components/Subheader/subheader.tsx
+++ b/components/Releases/components/Card/components/Subheader/subheader.tsx
@@ -1,18 +1,19 @@
-import { Dot } from "@databiosphere/findable-ui/lib/components/common/Dot/dot";
-import { JSX } from "react";
+import { Fragment, JSX } from "react";
 import { BaseReleaseData } from "../../../../data/types";
-import { STACK_PROPS } from "./constants";
-import { StyledStack } from "./subheader.styles";
-import { renderStudyIdentifier } from "./utils";
+import { StyledBox, StyledDot } from "./subheader.styles";
+import { getSubheaderParts } from "./utils";
 
 export const Subheader = (
   props: Pick<BaseReleaseData, "childPhsId" | "duls" | "phsId">
 ): JSX.Element | null => {
   return (
-    <StyledStack {...STACK_PROPS}>
-      <span>{renderStudyIdentifier(props)}</span>
-      <Dot />
-      <span>{props.duls.join(", ") || "No DULs"}</span>
-    </StyledStack>
+    <StyledBox>
+      {getSubheaderParts(props).map((part, i) => (
+        <Fragment key={i}>
+          {i > 0 && <StyledDot />}
+          <span>{part}</span>
+        </Fragment>
+      ))}
+    </StyledBox>
   );
 };

--- a/components/Releases/components/Card/components/Subheader/utils.ts
+++ b/components/Releases/components/Card/components/Subheader/utils.ts
@@ -2,6 +2,23 @@ import { ReactNode } from "react";
 import { BaseReleaseData } from "../../../../data/types";
 
 /**
+ * Returns the subheader parts for a release, omitting the study identifier when
+ * the release has no PHS ID. Without this, studies registered as "N/A" render a
+ * leading separator with nothing before it.
+ * @param release - The release object containing PHS IDs and DULs.
+ * @returns The subheader parts, in display order.
+ */
+export function getSubheaderParts(
+  release: Pick<BaseReleaseData, "childPhsId" | "duls" | "phsId">
+): ReactNode[] {
+  const parts: ReactNode[] = [];
+  const studyIdentifier = renderStudyIdentifier(release);
+  if (studyIdentifier) parts.push(studyIdentifier);
+  parts.push(release.duls.join(", ") || "No DULs");
+  return parts;
+}
+
+/**
  * Renders the study identifier for a release.
  * If there is a child PHS ID, it returns both parent and child IDs.
  * Otherwise, it returns just the PHS ID.

--- a/components/Releases/components/Card/components/Subheader/utils.ts
+++ b/components/Releases/components/Card/components/Subheader/utils.ts
@@ -20,14 +20,15 @@ export function getSubheaderParts(
 
 /**
  * Renders the study identifier for a release.
- * If there is a child PHS ID, it returns both parent and child IDs.
- * Otherwise, it returns just the PHS ID.
+ * If both parent and child PHS IDs are present, it returns both, labelled.
+ * Otherwise, it returns whichever ID is present, or null when neither is.
  * @param release - The release object containing PHS IDs.
  * @returns The formatted study identifier.
  */
 export function renderStudyIdentifier(
   release: Pick<BaseReleaseData, "childPhsId" | "phsId">
 ): ReactNode {
+  if (!release.phsId) return release.childPhsId ?? null;
   if (!release.childPhsId) return release.phsId;
 
   return `${release.phsId} (parent), ${release.childPhsId} (child)`;

--- a/docs/releases/2026/07/data-additions.json
+++ b/docs/releases/2026/07/data-additions.json
@@ -1,0 +1,201 @@
+[
+  {
+    "dataLibraryUrl": null,
+    "dataWorkspaceUrl": "https://anvil.terra.bio/#workspaces/anvil-datastorage/AnVIL_dGTEx_GRU_v1",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs003838.v1.p1",
+    "description": "The first data release of the Developmental GTEx (dGTEx) contains 379 samples (342 RNA-seq and 37 WGS) from 40 subjects.",
+    "duls": ["GRU"],
+    "explorerUrl": null,
+    "phsId": "phs003838.v1.p1",
+    "studyName": "Developmental Genotype Tissue Expression (dGTEx) Project",
+    "studyUrl": "https://gtexportal.org/home/aboutDGtex",
+    "submitterBlogPost": "https://gtexportal.org/home/home/news?id=610"
+  },
+  {
+    "dataLibraryUrl": null,
+    "dataWorkspaceUrl": "https://anvil.terra.bio/#workspaces/anvil-datastorage/AnVIL_nhp_dGTEx_V1",
+    "dbGapUrl": null,
+    "description": "The first data release of the Non-Human Primate Developmental GTEx (dGTEx) Project contains 421 Macaque samples (372 RNA-seq and 49 WGS) from 50 subjects, and 333 Marmoset samples (314 RNA-seq and 19 WGS) from 20 subjects.",
+    "duls": [],
+    "explorerUrl": null,
+    "phsId": null,
+    "studyName": "Non-Human Primate Developmental GTEx (dGTEx) Project",
+    "studyUrl": "https://gtexportal.org/home/aboutNHPdGtex",
+    "submitterBlogPost": "https://gtexportal.org/home/home/news?id=610"
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/94",
+    "dbGapUrl": null,
+    "description": "Release 2 contains the full release, including sequencing data, assemblies, and annotations from 232 individuals, directly within AnVIL, enabling streamlined analysis alongside other hosted datasets and tools. This addition complements existing access points, including HPRC's AWS S3 bucket, the HPRC Data Explorer, and INSDC, giving the community flexibility in how they work with the data.\n\nAs with all HPRC data, please refer to the consortium publication policy and best practices when using this pre-publication resource.",
+    "duls": [],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.title%22%2C%22value%22%3A%5B%22ANVIL_HPRC%22%2C%22AnVIL_HPRC_R2%22%5D%7D%5D",
+    "phsId": null,
+    "studyName": "Human Pangenome Reference Consortium",
+    "studyUrl": "https://humanpangenome.org/",
+    "submitterBlogPost": "https://humanpangenome.org/hprc-data-release-2/"
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/107",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs003047.v5.p4",
+    "description": "This fifth data release from the GREGoR Consortium expands the dataset to 12,292 participants from more than 5,000 families. The GREGoR dataset includes short-read whole exomes and genomes, long-read whole genomes, short-read ATAC-seq data, short and long-read RNA-seq, fiber-seq data, with linked phenotype and family structure. The dataset is well documented and structured in accordance with the GREGoR Data model. More information about the GREGoR Dataset is available via the Consortium's \"[GREGoR Data for the Scientific Community](https://gregorconsortium.org/data)\" page.",
+    "duls": ["GRU", "HMB"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs003047%22%5D%7D%5D",
+    "phsId": "phs003047.v5.p4",
+    "studyName": "NHGRI GREGoR Consortium: Genomics Research to Elucidate the Genetics of Rare Disease",
+    "studyUrl": "https://gregorconsortium.org/",
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/3394",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001616.v2.p2",
+    "description": "Please refer to the dbGaP study page for more information.\n\nClinical data from this eMERGE dataset was harmonized to OMOP 5.3. Users may find information about the OMOP transformation in [these release notes](https://docs.google.com/document/d/1SMDxadoCNFcDw3_Fk-M42QJuUrblVIn4LdHkAzkgfkc/preview).",
+    "duls": [
+      "GRU",
+      "GRU-IRB",
+      "GRU-IRB-NPU",
+      "GRU-IRB-PUB-NPU",
+      "HMB",
+      "HMB-GSO",
+      "HMB-NPU",
+      "GRU-NPU",
+      "HMB-IRB-PUB"
+    ],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs001616%22%5D%7D%5D",
+    "phsId": "phs001616.v2.p2",
+    "studyName": "eMERGE Network Phase III Clinical Sequencing: eMERGEseq Panel",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/3759",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000906.v1.p1",
+    "description": "Please refer to the dbGaP study page for more information.\n\nClinical data from this eMERGE dataset was harmonized to OMOP 5.3. Users may find information about the OMOP transformation in [these release notes](https://docs.google.com/document/d/16NzBfbXS-SBEI9d1R-q3Oc6SJ7jrMnXauN0y13H2DyA/preview).",
+    "duls": ["HMB", "DS-DEM", "GRU"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs000906%22%5D%7D%5D",
+    "phsId": "phs000906.v1.p1",
+    "studyName": "eMERGE Network's Multi-Center Pilot of Pharmacogenetic Sequencing in Clinical Practice",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/3392",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001584.v2.p2",
+    "description": "Please refer to the dbGaP study page for more information.\n\nClinical data from this eMERGE dataset was harmonized to OMOP 5.3. Users may find specific information about the OMOP transformation in [these release notes](https://docs.google.com/document/d/1jnNQ_CfpVHQ5uypU8NCWaoaBaRy8Dt1TwOemkF-sTvM/preview).",
+    "duls": [
+      "GRU",
+      "GRU-IRB-PUB-GSO",
+      "GRU-IRB-NPU",
+      "HMB",
+      "HMB-MDS",
+      "DS-CHILDD",
+      "DS-DEM",
+      "HMB-PUB-GSO",
+      "GRU-IRB-PUB",
+      "HMB-GSO"
+    ],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs001584%22%5D%7D%5D",
+    "phsId": "phs001584.v2.p2",
+    "studyName": "eMERGE Network Phase III: HRC SNV and 1000 Genomes SV Imputed Array Data of 105,000 Participants",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/3918",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs004069.v1.p1",
+    "description": "Please refer to the dbGaP study page for more information.",
+    "duls": ["GRU", "HMB"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs004069%22%5D%7D%5D",
+    "phsId": "phs004069.v1.p1",
+    "studyName": "A Depression and Opioid Pragmatic Trial in Pharmacogenetics (ADOPT PGx): Depression Trial",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/3919",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs004045.v1.p1",
+    "description": "Please refer to the dbGaP study page for more information.",
+    "duls": ["GRU", "HMB"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs004045%22%5D%7D%5D",
+    "phsId": "phs004045.v1.p1",
+    "studyName": "Genetic Testing to Understand and Address Renal Disease Disparities across the United States (GUARDD-US)",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/65",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001398.v1.p1",
+    "description": "Please refer to the dbGaP study page for more information.",
+    "duls": ["GRU"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs001398%22%5D%7D%5D",
+    "phsId": "phs001398.v1.p1",
+    "studyName": "Center for Common Disease Genomics [CCDG] - Cardiovascular: The Bangladesh Risk of Acute Vascular Events (BRAVE) Study",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/3500",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002243.v1.p1",
+    "description": "Please refer to the dbGaP study page for more information.",
+    "duls": ["HMB-MDS"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs002243%22%5D%7D%5D",
+    "phsId": "phs002243.v1.p1",
+    "studyName": "Center for Common Disease Genomics [CCDG] - Cardiovascular: PEGASUS-TIMI 54",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/3492",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002242.v1.p1",
+    "description": "Please refer to the dbGaP study page for more information.",
+    "duls": ["DS-DCCA-NPU-MDS"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs002242%22%5D%7D%5D",
+    "phsId": "phs002242.v1.p1",
+    "studyName": "Center for Common Disease Genomics [CCDG] - Cardiovascular: SWISS-AF/SWISS-AF-PVI/BEAT-AF",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/201",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs003499.v1.p1",
+    "description": "Please refer to the dbGaP study page for more information.",
+    "duls": ["HMB-PUB", "HMB-PUB-COL"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs003499%22%5D%7D%5D",
+    "phsId": "phs003499.v1.p1",
+    "studyName": "Center for Common Disease Genomics (CCDG) - Cardiovascular: Multiethnic Cohort",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/3886",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs004430.v1.p1",
+    "description": "Please refer to the dbGaP study page for more information.",
+    "duls": ["DS-ASD-ID-IRB-PUB-COL-NPU-GSO"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs004430%22%5D%7D%5D",
+    "phsId": "phs004430.v1.p1",
+    "studyName": "Center for Common Disease Genomics (CCDG) - Neuropsychiatric: Introduction of Exome/Genome Sequencing",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/67",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002502.v3.p1",
+    "description": "Additional data added under GRU and HMB-MDS. Please refer to the dbGaP study page for more information.",
+    "duls": ["GRU", "HMB-MDS"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs002502%22%5D%7D%5D",
+    "phsId": "phs002502.v3.p1",
+    "studyName": "Center for Common Disease Genomics [CCDG] Neuropsychiatric: Autism Spectrum Disorder (ASD) – Whole Exomes",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  },
+  {
+    "dataLibraryUrl": "https://duos.org/studies/62",
+    "dbGapUrl": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001642.v2.p1",
+    "description": "Additional data added under GRU. Please refer to the dbGaP study page for more information.",
+    "duls": ["GRU"],
+    "explorerUrl": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs001642%22%5D%7D%5D",
+    "phsId": "phs001642.v2.p1",
+    "studyName": "Center for Common Disease Genomics [CCDG] - Autoimmune: Inflammatory Bowel Disease (IBD) Exomes and Genomes",
+    "studyUrl": null,
+    "submitterBlogPost": null
+  }
+]

--- a/docs/releases/2026/07/data-modifications.json
+++ b/docs/releases/2026/07/data-modifications.json
@@ -1,0 +1,18 @@
+[
+  {
+    "datasetsAffected": [],
+    "description": "Two files in the current dataset ([Explorer](https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_identifier%22%2C%22value%22%3A%5B%22phs003472%22%5D%7D%5D)/[Data Library](https://duos.org/studies/191)) were found to have errors and were replaced in this data release.\n\nPlease reach out to [anvil-data@broadinstitute.org](mailto:anvil-data@broadinstitute.org) if more information is needed.",
+    "duls": ["Unrestricted", "Mouse"],
+    "phsId": "phs003472.v1.p1",
+    "studyName": "Impact of Genomic Variation on Function (IGVF) Consortium",
+    "studyUrl": "https://igvf.org/"
+  },
+  {
+    "datasetsAffected": [],
+    "description": "New data snapshots were generated to address data update requests. The impacted datasets are versions 1-4 under the General Research Use Data Use Limitation (GRU DUL) and versions 2-4 under the Health/Medical/Biomedical.",
+    "duls": ["GRU", "HMB"],
+    "phsId": "phs003047 versions 1-4",
+    "studyName": "NHGRI GREGoR Consortium: Genomics Research to Elucidate the Genetics of Rare Disease",
+    "studyUrl": "https://gregorconsortium.org/"
+  }
+]

--- a/docs/releases/2026/07/release-notes.mdx
+++ b/docs/releases/2026/07/release-notes.mdx
@@ -1,0 +1,30 @@
+---
+breadcrumbs:
+  - path: "/"
+    text: "Home"
+  - path: "/releases"
+    text: "Releases"
+  - path: ""
+    text: "July 2026 Release"
+date: "2026-07-01"
+description: "July 2026 Data Release"
+title: "July 2026 Release"
+---
+
+The AnVIL team is excited to announce the release of the following studies on the AnVIL platform as well as modifications to existing datasets on AnVIL.
+
+If you are interested in these datasets, please submit data access requests through dbGaP. The datasets are now findable on the [AnVIL Data Explorer](https://explore.anvilproject.org/datasets) for cohort building and on the [AnVIL Data Library](https://duos.org/datalibrary/anvil) for dataset-level search.
+
+For additional resources, please refer to [finding and using AnVIL data](https://support.terra.bio/hc/en-us/articles/34594440468635-Finding-and-using-AnVIL-data).
+
+## New Data Releases
+
+<DataAdditions {...releaseData} />
+
+## Data Modifications to Existing Releases
+
+<DataModifications {...releaseData} />
+
+## Developmental Enhancements and Bug Fixes
+
+None to report.


### PR DESCRIPTION
## Summary

Closes #4061

Adds the July 2026 AnVIL release notes, transcribed from the [source Google Doc](https://docs.google.com/document/d/1J6dj7FG7TOJElKm3KiLYrwZqSC694Py_5s_E45NJIQI/edit), plus a fix to the shared release-card subheader that the new content exposed.

Two commits:

1. `content:` — the July 2026 release notes (16 new data releases, 2 data modifications)
2. `fix:` — separator alignment and wrapping in the release card subheader

## Content

| File | Change |
| --- | --- |
| `docs/releases/2026/07/release-notes.mdx` | New page, modelled on the March 2026 release notes |
| `docs/releases/2026/07/data-additions.json` | 16 studies |
| `docs/releases/2026/07/data-modifications.json` | 2 studies |

The page is picked up by `/releases` automatically — that index scans the filesystem, so no manual listing was needed.

**Note on the issue's "How" section:** it says to model this on `docs/releases/2026/05/release-notes.mdx` with a study-changes table. That guidance predates #4062, which replaced those tables with cards. July is also a full release rather than a pre-release, so this follows the March 2026 pattern (`DataAdditions` / `DataModifications` + JSON) instead.

## Subheader fix

The new content has two studies registered as `N/A` (Non-Human Primate dGTEx, HPRC), and one with nine DUL codes. Both broke the existing subheader:

- **Orphaned separator** — with no phsID the subheader rendered a leading bullet with nothing before it (`• No DULs`). `getSubheaderParts()` now omits absent parts and the separator renders *between* parts rather than unconditionally.
- **Wrapping** — the flex layout forced long DUL lists onto their own line. The subheader is now normal inline flow, so the list wraps naturally around the separator.

This also fixes the same orphaned bullet on the **March 2026** page's HPRC card, which is live today.

The separator is a local `styled.span` rather than findable-ui's `Dot`; the shared one is built for flex parents (`display: block; align-self: center; flex: none`), which is what forced the wrapping.

## Verification

Alignment measured on the built output against a zero-height probe whose bottom edge is the text baseline:

- dot centre sits **4.73px** above the baseline
- cap-height midpoint for 13px Inter (`0.7275em`) is **4.73px** — delta 0.00px
- every dot computes to `inline-block`, 4×4px

Checked on all four pages that use the shared component:

| Page | Cards | Dots | Offset | Orphans |
| --- | --- | --- | --- | --- |
| July 2026 (new) | 18 | 16 | 4.73px | 0 |
| March 2026 | 9 | 8 | 4.73px | 0 |
| November 2025 | 10 | 10 | 4.73px | 0 |
| August 2025 | 10 | 10 | 4.73px | 0 |

Link counts on the new page tally exactly with the source doc: 14 Request Access, 14 Data Explorer, 14 Data Library, 2 Data Workspace, 3 Read Blog Post, and 7 inline links all resolving to real anchors.

`tsc --noEmit`, `npm run lint` (only the pre-existing `sonarjs/todo-tag` warning), `npm run check-format`, and a full production build all pass.

## Notes for review

- **The GREGoR data-modification text is incomplete in the source doc.** It ends `"...and versions 2-4 under the Health/Medical/Biomedical."` with no noun — the parallel clause suggests `"Health/Medical/Biomedical Data Use Limitation (HMB DUL)"`. Identical in both copies of the doc, so it is an authoring gap rather than a transcription error. **Left verbatim** — needs an author fix.
- **eMERGE release-notes links use `/preview`** rather than `/edit`, so readers get a clean read-only view with no editor chrome. The three linked docs are publicly readable; the parent release-communications doc is not.
- Two studies show `No DULs` with no phsID, matching the `N/A` values in the source.

<img width="1728" height="886" alt="image" src="https://github.com/user-attachments/assets/533111f5-0f44-4354-bb0a-02a2d2472775" />

<img width="1728" height="849" alt="image" src="https://github.com/user-attachments/assets/8d301f2b-6ea5-451d-b52e-9ce92dbf4f06" />

