### PR TITLE
content: amend july 2026 release notes to complete gregor data use limitation text (#4066)

### DIFF
--- a/docs/releases/2026/07/data-modifications.json
+++ b/docs/releases/2026/07/data-modifications.json
@@ -9,7 +9,7 @@
   },
   {
     "datasetsAffected": [],
-    "description": "New data snapshots were generated to address data update requests. The impacted datasets are versions 1-4 under the General Research Use Data Use Limitation (GRU DUL) and versions 2-4 under the Health/Medical/Biomedical.",
+    "description": "New data snapshots were generated to address data update requests. The impacted datasets are versions 1-4 under the General Research Use Data Use Limitation (GRU DUL) and versions 2-4 under the Health/Medical/Biomedical Data Use Limitation (HMB DUL).",
     "duls": ["GRU", "HMB"],
     "phsId": "phs003047 versions 1-4",
     "studyName": "NHGRI GREGoR Consortium: Genomics Research to Elucidate the Genetics of Rare Disease",


### PR DESCRIPTION
## Summary

Closes #4066

Completes the truncated Data Use Limitation phrase in the GREGoR entry of the July 2026 release notes, under *Data Modifications to Existing Releases*.

Requested by Kate Balaconis (Slack, 28 July 2026) after reviewing the published page.

## Change

One field: the `description` of the second entry in `docs/releases/2026/07/data-modifications.json`.

**Before** — sentence ends on a dangling adjective:

> ...and versions 2-4 under the Health/Medical/Biomedical.

**After** — parallel with the GRU clause earlier in the same sentence:

> ...and versions 2-4 under the Health/Medical/Biomedical Data Use Limitation (HMB DUL).

## Verification

Confirmed on the built output that the card renders the full sentence:

> New data snapshots were generated to address data update requests. The impacted datasets are versions 1-4 under the General Research Use Data Use Limitation (GRU DUL) and versions 2-4 under the Health/Medical/Biomedical Data Use Limitation (HMB DUL).

JSON parses, 18 cards still render, prettier and a full production build pass.

## Notes

- The truncation came from the source Google Doc, [AnVIL: Quarterly Release Communications_July 2026](https://docs.google.com/document/d/1J6dj7FG7TOJElKm3KiLYrwZqSC694Py_5s_E45NJIQI/edit), which has the same wording. It was left verbatim in #4061 rather than guessing at text for a public page; Kate has since confirmed the intended wording. Worth correcting the source doc too so the next quarterly transcription doesn't reintroduce it — out of scope for this PR.
- Content only; no component changes.

<img width="2483" height="1191" alt="image" src="https://github.com/user-attachments/assets/078080be-8683-496d-a434-44e4322a2316" />
