### PR TITLE
chore: exclude 2025-02-10 bot traffic from portal analytics report (#4077)

### DIFF
--- a/analytics/anvil-analytics-portal/sheets/constants.py
+++ b/analytics/anvil-analytics-portal/sheets/constants.py
@@ -9,6 +9,10 @@ SHEET_NAME = "AnVIL Portal"
 
 ANVIL_PORTAL_ID = "368678391"
 
+# Dates of known synthetic/bot traffic (headless-browser burst, likely a load test)
+# to exclude from reports; see anvilproject/anvil-portal#4077.
+EXCLUDE_BOT_TRAFFIC_DATES = ["2025-02-10"]
+
 HISTORIC_UA_DATA_PATH = "../users_over_time_history.json"
 SECRET_NAME = 'ANVIL_ANALYTICS_REPORTING_CLIENT_SECRET_PATH'
 GA_PROPERTY_PORTAL = "368678391" # AnVIL Portal - GA4

--- a/analytics/anvil-analytics-portal/sheets/generate_static_site.py
+++ b/analytics/anvil-analytics-portal/sheets/generate_static_site.py
@@ -9,6 +9,7 @@ from constants import (
     ANVIL_PORTAL_ID,
     ANALYTICS_START,
     CURRENT_MONTH,
+    EXCLUDE_BOT_TRAFFIC_DATES,
     EXCLUDE_PAGES_FILTER,
     HISTORIC_UA_DATA_PATH,
     OAUTH_PORT,
@@ -49,6 +50,7 @@ def main():
         ],
         base_dimension_filter=EXCLUDE_PAGES_FILTER,
         search_path="/search",
+        exclude_dates=EXCLUDE_BOT_TRAFFIC_DATES,
     )
 
 

--- a/analytics/anvil-analytics-portal/sheets/readme.md
+++ b/analytics/anvil-analytics-portal/sheets/readme.md
@@ -39,3 +39,4 @@ The script is configured with:
 - **Page exclusions**: `/guides/content/creating-links` and `/guides/content/editing-an-existing-page` are excluded from the pageviews detail table
 - **Search queries**: Extracted from `/search?q=` page paths
 - **File downloads**: GA4 enhanced measurement `file_download` events
+- **Date exclusions**: Days with known synthetic/bot traffic are excluded from all GA4 queries (`EXCLUDE_BOT_TRAFFIC_DATES` in `constants.py`); historic UA data is unaffected

--- a/analytics/anvil-analytics-portal/sheets/site/data/meta.json
+++ b/analytics/anvil-analytics-portal/sheets/site/data/meta.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06 22:37:19",
+  "generated_at": "2026-08-08 00:15:13",
   "current_month": "2026-07",
   "current_month_start": "2026-07-01",
   "current_month_end": "2026-07-31",

--- a/analytics/anvil-analytics-portal/sheets/site/data/monthly_traffic.json
+++ b/analytics/anvil-analytics-portal/sheets/site/data/monthly_traffic.json
@@ -86,8 +86,8 @@
   },
   {
     "month": "2025-02",
-    "users": 7073,
-    "pageviews": 11774
+    "users": 2043,
+    "pageviews": 4522
   },
   {
     "month": "2025-01",


### PR DESCRIPTION
Closes #4077

## What changed

- `analytics/anvil-analytics-portal/sheets/constants.py`: new `EXCLUDE_BOT_TRAFFIC_DATES = ["2025-02-10"]` constant documenting the known synthetic-traffic date.
- `analytics/anvil-analytics-portal/sheets/generate_static_site.py`: passes it as `exclude_dates` to the shared generator (feature added in DataBiosphere/data-browser#4907).
- `analytics/anvil-analytics-portal/sheets/readme.md`: documents the date-exclusion configuration (GA4 queries only; historic UA data unaffected).
- Regenerated `sheets/site/`: only `monthly_traffic.json` (Feb 2025: 7,073 → 2,043 users, 11,774 → 4,522 pageviews) and `meta.json` (timestamp) changed; all other data files byte-identical, July stats untouched.

## Why

GA4 recorded a synthetic traffic burst on 2025-02-10: 5,051 "users" in one day (baseline: 28–139/day) sharing a single headless-Chrome fingerprint — the same load-test-style burst excluded from the AnVIL Explorer report in DataBiosphere/data-browser#4908. It shows as a bogus spike in the dashboard's Monthly Traffic chart. GA4 can't retroactively remove data, so the report queries exclude the date. Query-side exclusion keeps GA's user deduplication correct; client-side subtraction would corrupt user metrics.

## Assumptions I made

- One day only for the Portal: GA4 daily breakdown shows 2025-02-11 was normal here (95 users), unlike the Explorer, which was hit both days.
- Date exclusion over fingerprint filtering (a fingerprint filter would silently drop matching traffic forever); losing the ~70 real users on that day is ~0.1% of the chart's range.
- Legacy consumers in this repo (the Sheets notebook and Jupyter Book notebooks, which query the same property without the exclusion) were deliberately not patched — they're scheduled for deletion in #4079.
- The regenerated numbers were verified against a direct GA4 Data API query composing the audience filter with the date exclusion (2,043 users / 4,522 pageviews) before committing.

## How to verify

Definition of done from #4077: the report excludes 2025-02-10 and the regenerated site no longer shows the spike.

1. Open `analytics/anvil-analytics-portal/sheets/site/data/monthly_traffic.json` and find `2025-02`: it should read 2,043 users / 4,522 pageviews (previously 7,073 / 11,774), in line with 2025-01's 2,011.
2. Serve locally (`cd analytics/anvil-analytics-portal/sheets/site && python -m http.server 8080`) and check the Monthly Traffic Over Time chart — the Feb 2025 spike is gone.
3. Confirm the only other changed data file is `meta.json` (timestamp); July 2026 stats are unchanged (3,511 sessions).
4. Optional end-to-end: run `generate_static_site.py` (GA4 OAuth required) — console prints "Excluding dates from all queries: 2025-02-10".

🤖 Generated with [Claude Code](https://claude.com/claude-code)