### PR TITLE
content: feature acc2026 in the homepage carousel and hold it there (#4082)

### DIFF
--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -10,6 +10,18 @@ const ACTION_LABEL = {
 
 const CAROUSEL_CARDS: SectionCard[] = [
   {
+    links: [
+      {
+        label: ACTION_LABEL.LEARN_MORE,
+        target: ANCHOR_TARGET.SELF,
+        url: "/events/anvil2026-community-conference",
+      },
+    ],
+    persistent: true,
+    text: "Join us August 31 - September 1, 2026 in Cambridge, MA for the AnVIL Community Conference — featuring keynote speakers, workshops, poster sessions, and the latest in genomics analysis in the cloud.",
+    title: "AnVIL Community Conference 2026",
+  },
+  {
     date: "2026-05-01",
     links: [
       {
@@ -21,18 +33,6 @@ const CAROUSEL_CARDS: SectionCard[] = [
     text: "AnVIL has partnered with AWS to make major genomic datasets freely available, eliminating data transfer fees that previously exceeded $15,000 for some datasets.",
     title:
       "AnVIL Makes Groundbreaking Genomic Datasets Available on AWS for Free",
-  },
-  {
-    links: [
-      {
-        label: ACTION_LABEL.LEARN_MORE,
-        target: ANCHOR_TARGET.SELF,
-        url: "/events/anvil2026-community-conference",
-      },
-    ],
-    persistent: true,
-    text: "Join us August 31 - September 1, 2026 in Cambridge, MA for the AnVIL Community Conference — featuring keynote speakers, workshops, poster sessions, and the latest in genomics analysis in the cloud.",
-    title: "AnVIL Community Conference 2026",
   },
   {
     date: "2026-04-07",


### PR DESCRIPTION
## Summary

Closes #4082

Moves the "AnVIL Community Conference 2026" card to the front of `CAROUSEL_CARDS` in `components/Home/components/Section/components/SectionHero/common/utils.ts` so it is the first card shown in the homepage hero carousel. The card was already `persistent: true` (added in #3949), so it remains featured regardless of the recent-content window — at least through the conference (August 31 – September 1, 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2560" height="1184" alt="image" src="https://github.com/user-attachments/assets/db9f1340-f16f-4994-8859-2daacb74d51a" />
