### PR TITLE
feat: add a flag to toggle homepage carousel auto-rotation, and pause it (#4086)

### DIFF
--- a/components/Home/components/Bullets/bullets.tsx
+++ b/components/Home/components/Bullets/bullets.tsx
@@ -19,6 +19,8 @@ export const Bullets = ({
       {bullets.map((bullet) => (
         <Bullet
           key={bullet}
+          aria-current={activeBullet === bullet || undefined}
+          aria-label={`Show slide ${bullet + 1}`}
           isActive={activeBullet === bullet}
           onClick={(): void => {
             onBullet(bullet);

--- a/components/Home/components/Section/components/SectionHero/components/Carousel/common/constants.ts
+++ b/components/Home/components/Section/components/SectionHero/components/Carousel/common/constants.ts
@@ -1,3 +1,5 @@
+export const AUTO_ROTATE = false;
+export const AUTO_ROTATE_DELAY = 8000;
 export const CARD_OFFSET_Y = 8;
 export const CARD_SCALE_X = 48;
 export const MIN_CONTENT_CARD_HEIGHT = 160;

--- a/components/Home/components/Section/components/SectionHero/components/Carousel/common/constants.ts
+++ b/components/Home/components/Section/components/SectionHero/components/Carousel/common/constants.ts
@@ -1,4 +1,4 @@
-export const AUTO_ROTATE = false;
+export const AUTO_ROTATE: boolean = false;
 export const AUTO_ROTATE_DELAY = 8000;
 export const CARD_OFFSET_Y = 8;
 export const CARD_SCALE_X = 48;

--- a/components/Home/components/Section/components/SectionHero/components/Carousel/hooks/useInteractiveCarousel.ts
+++ b/components/Home/components/Section/components/SectionHero/components/Carousel/hooks/useInteractiveCarousel.ts
@@ -5,6 +5,7 @@ import {
   UseSwipeInteraction,
   useSwipeInteraction,
 } from "../../../../../../../hooks/useSwipeInteraction/useSwipeInteraction";
+import { AUTO_ROTATE, AUTO_ROTATE_DELAY } from "../common/constants";
 
 export interface UseInteractiveCarousel {
   activeIndex: UseSwipeInteraction["activeIndex"];
@@ -27,11 +28,11 @@ export function useInteractiveCarousel(): UseInteractiveCarousel {
     () => buildInteractiveIndexes(carouselCards),
     [carouselCards]
   );
-  // Get the active index and interactive actions.
+  // Get the active index and interactive actions; a swipe delay of 0 disables auto-rotation.
   const swipeInteraction = useSwipeInteraction(
     interactiveIndexes.length,
     true,
-    8000
+    AUTO_ROTATE ? AUTO_ROTATE_DELAY : 0
   );
   return {
     interactiveCards: carouselCards,

--- a/components/Home/hooks/useSwipeInteraction/useSwipeInteraction.tsx
+++ b/components/Home/hooks/useSwipeInteraction/useSwipeInteraction.tsx
@@ -31,7 +31,7 @@ export interface UseSwipeInteraction {
  * Swipe actions over swipe-able "views" i.e. cards, carousel cards, etc.
  * @param indexCount - Number of swipe-able / interactive "views".
  * @param swipeEnabled - Swipe interaction is enabled.
- * @param swipeDelay - Timeout delay for auto-swipe.
+ * @param swipeDelay - Timeout delay for auto-swipe; a delay of 0 disables auto-swipe.
  * @returns swipe actions and active swipe index.
  */
 export function useSwipeInteraction(

--- a/docs/events/README.md
+++ b/docs/events/README.md
@@ -41,4 +41,6 @@ The home page Updates section (Events tab) shows only upcoming `featured` events
 
 The hero carousel uses a 3-month freshness window: dated entries within the last 3 months show by default. Set `persistent: true` to keep an event eligible regardless of date — useful for recurring conferences.
 
+Note: carousel auto-rotation is currently paused (`AUTO_ROTATE` in `components/Home/components/Section/components/SectionHero/components/Carousel/common/constants.ts`), so the carousel holds on its first card — items behind it are only reached via manual navigation (arrows, bullets, or swipe).
+
 Use `hidden: true` to suppress an event from all listings.

--- a/docs/news/README.md
+++ b/docs/news/README.md
@@ -26,6 +26,8 @@ url: "https://..." # optional — external link (omit or use null otherwise)
 
 By default, the home page Updates section (and the hero carousel) only show items with a `date` within the last 3 months — older items fall off automatically.
 
+Note: carousel auto-rotation is currently paused (`AUTO_ROTATE` in `components/Home/components/Section/components/SectionHero/components/Carousel/common/constants.ts`), so the carousel holds on its first card — items behind it are only reached via manual navigation (arrows, bullets, or swipe).
+
 To keep an item visible past that window — e.g. a flagship announcement, an ongoing program, an evergreen paper — set `persistent: true`.
 
 The full news archive at `/news` shows everything regardless of date or `persistent`. Use `hidden: true` to suppress an item from all listings.


### PR DESCRIPTION
## Summary

Closes #4086

Adds an `AUTO_ROTATE` boolean flag (with an `AUTO_ROTATE_DELAY` of 8000ms) to the hero carousel constants and wires it into `useInteractiveCarousel`. When the flag is `false`, the swipe delay passed to `useSwipeInteraction` is `0`, which the hook treats as "no auto-advance" (`if (swipeDelay === 0) return;`), so the carousel holds on the first card. Manual navigation (swipe, arrows, bullets) is unaffected — those handlers are independent of the delay.

The flag ships set to `false`, pausing rotation as requested. To re-enable auto-rotation, flip `AUTO_ROTATE` to `true` in `components/Home/components/Section/components/SectionHero/components/Carousel/common/constants.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)