### PR TITLE
content: update anvil acc 2026 notice with updates from planning doc (#4090)

### DIFF
--- a/components/Home/components/Section/components/SectionHero/common/utils.ts
+++ b/components/Home/components/Section/components/SectionHero/common/utils.ts
@@ -18,7 +18,7 @@ const CAROUSEL_CARDS: SectionCard[] = [
       },
     ],
     persistent: true,
-    text: "Join us August 31 - September 1, 2026 in Cambridge, MA for the AnVIL Community Conference — featuring keynote speakers, workshops, poster sessions, and the latest in genomics analysis in the cloud.",
+    text: "Join us August 31 - September 1, 2026 in Cambridge, MA for the AnVIL Community Conference — featuring keynote speakers, workshops, poster sessions, and more. Register by August 17!",
     title: "AnVIL Community Conference 2026",
   },
   {

--- a/docs/events/anvil2026-101-virtual-workshop.mdx
+++ b/docs/events/anvil2026-101-virtual-workshop.mdx
@@ -23,7 +23,7 @@ This virtual workshop is designed for anyone who wants an introduction to the An
 
 Registration is now closed. Watch a recording of this event and sign up for the next one!
 
-Recording: https://youtu.be/LKoOEpA8NMk
+<Video src="https://www.youtube.com/embed/LKoOEpA8NMk" />
 
 Sign up for October 29, 2026: https://bit.ly/anvil101-oct2026
 

--- a/docs/events/anvil2026-community-conference.mdx
+++ b/docs/events/anvil2026-community-conference.mdx
@@ -77,7 +77,7 @@ Join us in Cambridge, MA to hear the latest and greatest of genomics analysis in
 
 - Join the Mailing List: https://lists.anvilproject.org/lists/acc2026.lists.anvilproject.org
 - How to register: https://bit.ly/anvil2026-register
-  - Costs: $108.55
+- Costs: $108.55
 - Hotel:
   - Residence Inn by Marriott Boston Cambridge
     - AnVIL Community Conference Room Block

--- a/docs/events/anvil2026-community-conference.mdx
+++ b/docs/events/anvil2026-community-conference.mdx
@@ -28,79 +28,70 @@ Join us in Cambridge, MA to hear the latest and greatest of genomics analysis in
 
 ![AnVIL Community Conference 2026](/consortia/events/acc2026-handout.webp)
 
-### 🗣 Keynote Speakers
+### 🗓 Agenda
 
-- Kristin Ardlie, Ph.D., Broad Institute of MIT and Harvard (GTEx)
-- Ben Heavner, Ph.D., University of Washington (GREGoR)
+#### Day 1 — Monday, August 31
 
-### 🧬 Invited Speakers
+| Time (ET) | Event                                                                                                                                                                                                                            |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2:00 pm   | **Workshops Kickoff**<br/>Broad Auditorium                                                                                                                                                                                        |
+| 2:15 pm   | **Part 1: Platform (concurrent)**<br/>AnVIL101 — Led by: Ava Hoffman — Broad Auditorium<br/>Retrospective: Peek Behind the Scenes — Led by: Jonathan Lawson — Broad Board Room                                                    |
+| 3:15 pm   | Break                                                                                                                                                                                                                             |
+| 3:30 pm   | **Part 2: Applications (concurrent)**<br/>All of Us & AnVIL Imputation Service Workshop — Led by: Chris Kachulis<br/>Exploring AI-enabled analyses with AnVIL — Led by: Vincent Carey<br/>DREAM Challenge — Led by: Kyle Ellrott |
+| 4:30 pm   | Break                                                                                                                                                                                                                             |
+| 4:45 pm   | **Part 3: Fishbowl Discussion**<br/>Broad Auditorium                                                                                                                                                                              |
+| 5:30 pm   | Close Day 1                                                                                                                                                                                                                       |
 
-- Jill Moore, Ph.D., UMass Chan (MOHD)
-- Heidi Rehm, Ph.D., Broad Institute of MIT and Harvard (seqr)
-- Benedict Paten, Ph.D., University of California Santa Cruz (HPRC)
-- Vasiliki Rahimzadeh, Ph.D., Baylor College of Medicine (AI & Data Policy with AnVIL)
-- John Landers, Ph.D., UMass Chan (ALS Compute)
+#### Day 2 — Tuesday, September 1
 
-### 🔬 Featured Talks
-
-New technologies & data in AnVIL, with spotlights on:
-
-- Terra - cloud platform for biomedical research
-- Bioconductor - open-source tools for bioinformatics
-- Galaxy - accessible, reproducible bioinformatics workflows
-- Dockstore - sharing and discovery of bioinformatics tools and workflows
-- AnVIL Data Explorer - browsing and querying AnVIL datasets
-- DUOS - Data Use Oversight System for streamlined data access
-
-### 📊 Poster Sessions
-
-Share your work in genomics and cloud computing with the community.
-
-### 🤝 Workshops
-
-Get onto the AnVIL platform at our workshops where you'll learn the basics of cloud computing for genomics research on AnVIL, explore new AI tools and technologies for analysis, and learn about using AnVIL for a variety of scientific applications. Join us for more workshop sessions to be announced soon!
-
-- AnVIL 101 — Get started with the AnVIL platform
-- AI on AnVIL — Explore AI tools and methods in the cloud
-- All of Us & AnVIL Imputation Service - Leverage the largest imputation panel to date
-- Scientific Applications on AnVIL
-- More workshops coming soon!
+| Time (ET) | Event                                                                                                    |
+| --------- | -------------------------------------------------------------------------------------------------------- |
+| 9:00 AM   | **Welcome to ACC26 at the Broad Institute**<br/>Speakers: Jonathan Lawson, Mike Schatz and Robert Carroll<br/>Auditorium |
+| 9:45 AM   | **Keynote — Ben Heavner**<br/>Auditorium                                                                  |
+| 10:15 AM  | Coffee break + Poster Viewing<br/>Lobby                                                                   |
+| 10:30 AM  | Invited + Submitted Talks<br/>Auditorium                                                                  |
+| 12:00 PM  | Poster Lightning Talks<br/>Auditorium                                                                     |
+| 12:15 PM  | Poster Session<br/>Lobby                                                                                  |
+| 12:45 PM  | Lunch + Networking                                                                                        |
+| 1:30 PM   | **Keynote — Kristin Ardlie**<br/>Auditorium                                                               |
+| 2:00 PM   | Invited + Submitted Talks<br/>Auditorium                                                                  |
+| 3:30 PM   | Snack Break<br/>Lobby                                                                                     |
+| 3:45 PM   | New Technologies & Data in AnVIL<br/>Auditorium                                                           |
+| 4:45 PM   | Closing Discussion + Ask Me Anything<br/>Auditorium                                                       |
+| 5:15 PM   | Poster Session + Networking Reception<br/>Lobby                                                           |
+| 6:00 PM   | Close                                                                                                     |
 
 ### Key Dates
 
 #### Registration for In-Person or Virtual Attendance
 
 - Opens May 5, 2026
-- Closes August 12, 2026
+- Closes August 17, 2026
 
 #### Abstract Submission
 
-- Opens May 1, 2026
-- **Abstract submission deadline extended until July 26th at midnight!**
-- Decisions for oral presentations returned August 1, 2026
-- Closes August 10, 2026 for poster presentations
-- Decisions for poster presentations returned August 11, 2026
+- Opens May 5, 2026
+- Closes August 12, 2026
 
 ### Event Details
 
 - Join the Mailing List: https://lists.anvilproject.org/lists/acc2026.lists.anvilproject.org
 - How to register: https://bit.ly/anvil2026-register
-- Submit an abstract for a talk or poster: https://bit.ly/anvil2026-abstract
-- Costs: $108.55
+  - Costs: $108.55
 - Hotel:
   - Residence Inn by Marriott Boston Cambridge
     - AnVIL Community Conference Room Block
     - Start Date: Monday, August 31, 2026
     - End Date: Thursday, September 3, 2026
-    - Special group rate: $239.00 USD per night
-    - Last Day to Book: Monday, August 10, 2026
+    - Special group rate: $239.00 per night
+    - Last Day to Book at Negotiated Rates: Monday, August 17, 2026
     - Link to Book:<br/>
-      https://www.marriott.com/event-reservations/reservation-link.mi?id=1775331883145&key=GRP&app=resvlink&_branch_match_id=1456056423690096870&_branch_referrer=H4sIAAAAAAAAA8soKSkottLXTywo0MtNLCrKzC8p0UvOz9UvSi3OyczLtgdK2ALZZSCOWmaKraG5uamxsaGFhbGhiapadmqlrXtQgFpdUWpaKlB3Xnp8UlF%2BeXFqka1zRlF%2BbioAvuHWy2AAAAA%3D
+      https://www.marriott.com/event-reservations/reservation-link.mi?id=1775331883145&key=GRP&app=resvlink&_branch_match_id=1456056423690096870&_branch_referrer=H4sIAAAAAAAAA8soKSkottLXTywo0MtNLCrKzC8p0UvOz9UvSi3OyczLtgdK2ALZZSCOWmaKraG5uamxsaGFhbGhialadmqlrXtQgFpdUWpaKlB3Xnp8UlF%2BeXFqka1zRlF%2BbioAvuHWy2AAAAA%3D
   - Boston Marriott Cambridge
     - AnVIL Community Conference Room Block
     - Start Date: Monday, August 31, 2026
     - End Date: Thursday, September 3, 2026
-    - Special group rate: $219.00 USD per night
-    - Last Day to Book: Monday, August 10, 2026
+    - Special group rate: $219.00 per night
+    - Last Day to Book at Negotiated Rates: Monday, August 17, 2026
     - Link to Book:<br/>
       https://www.marriott.com/event-reservations/reservation-link.mi?id=1775748371872&key=GRP&app=resvlink&_branch_match_id=1456056423690096870&_branch_referrer=H4sIAAAAAAAAA8soKSkottLXTywo0MtNLCrKzC8p0UvOz9UvSi3OyczLtgdK2ALZZSCOWmaKraG5uam5iYWxuaGFuZFadmqlrXtQgFpdUWpaKlB3Xnp8UlF%2BeXFqka1zRlF%2BbioA9aGMmGAAAAA%3D

--- a/docs/events/anvil2026-community-conference.mdx
+++ b/docs/events/anvil2026-community-conference.mdx
@@ -33,7 +33,7 @@ Join us in Cambridge, MA to hear the latest and greatest of genomics analysis in
 #### Day 1 — Monday, August 31
 
 | Time (ET) | Event                                                                                                                                                                                                                            |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 2:00 pm   | **Workshops Kickoff**<br/>Broad Auditorium                                                                                                                                                                                        |
 | 2:15 pm   | **Part 1: Platform (concurrent)**<br/>AnVIL101 — Led by: Ava Hoffman — Broad Auditorium<br/>Retrospective: Peek Behind the Scenes — Led by: Jonathan Lawson — Broad Board Room                                                    |
 | 3:15 pm   | Break                                                                                                                                                                                                                             |
@@ -45,7 +45,7 @@ Join us in Cambridge, MA to hear the latest and greatest of genomics analysis in
 #### Day 2 — Tuesday, September 1
 
 | Time (ET) | Event                                                                                                    |
-| --------- | -------------------------------------------------------------------------------------------------------- |
+| :-------- | :------------------------------------------------------------------------------------------------------- |
 | 9:00 AM   | **Welcome to ACC26 at the Broad Institute**<br/>Speakers: Jonathan Lawson, Mike Schatz and Robert Carroll<br/>Auditorium |
 | 9:45 AM   | **Keynote — Ben Heavner**<br/>Auditorium                                                                  |
 | 10:15 AM  | Coffee break + Poster Viewing<br/>Lobby                                                                   |


### PR DESCRIPTION
## Summary

Closes #4090

Updates the ACC 2026 event page (`docs/events/anvil2026-community-conference.mdx`) from the latest planning doc:

- Adds the full two-day agenda (Day 1 workshop schedule, Day 2 talks/keynotes/posters) as left-aligned tables.
- Key dates updated: registration now closes August 17, 2026; abstract submission opens May 5 and closes August 12, 2026 (extended-deadline/decision lines removed).
- Hotel blocks: last day to book at negotiated rates is now August 17, 2026 for both hotels; the Residence Inn booking URL now matches the doc byte-for-byte (the previous page copy had diverged).
- Removes the speaker/talk/poster/workshop sections now superseded by the agenda, and the stale abstract-submission link.
- The homepage carousel card copy now ends with “…poster sessions, and more. Register by August 17!” to surface the registration deadline.

Also carries a small ride-along: the AnVIL 101 Virtual Workshop recording is now embedded via the `Video` MDX component instead of a bare YouTube link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2560" height="1047" alt="image" src="https://github.com/user-attachments/assets/33f7f6d3-3cce-4cd0-a114-b70b60da06b3" />

<img width="2555" height="1182" alt="image" src="https://github.com/user-attachments/assets/7e459522-0271-40a6-a1c7-3b3ddf886d48" />


<img width="2560" height="1221" alt="image" src="https://github.com/user-attachments/assets/c6a570cb-2263-4694-87b3-70fef9648446" />

