### PR TITLE
content: update overview of account setup page from account setup planning doc (#4095)

### DIFF
--- a/docs/learn/get-started/overview-of-account-setup.mdx
+++ b/docs/learn/get-started/overview-of-account-setup.mdx
@@ -8,18 +8,18 @@ title: "Overview of Account Setup"
 
 To use AnVIL, you will need a Google account to authenticate with Terra and the AnVil Data Explorer and to associate your Terra account with a Google Cloud Platform (GCP) account.
 
-If you are accessing controlled-access data, you will also need an eRA commons id or to be a member of a data-sharing consortium.
+If you are accessing controlled-access data, you will also need an NIH RAS ID or to be a member of a data-sharing consortium.
 
-To enable dbGaP data use authorizations to flow through from dbGaP to Terra, you must link your Terra account with your eRA Commons ID.
+To enable dbGaP data use authorizations to flow through from dbGaP to Terra, you must link your Terra account with your NIH RAS ID.
 
 The guides below walk you through each step in the account setup process.
 
 ## Account Setup Checklist
 
-1. [Set up a Terra account](https://support.terra.bio/hc/en-us/articles/360028235911-How-to-register-for-a-Terra-account) - To register for a [Terra](https://anvil.terra.bio/#workspaces) account, you will need a Gmail account or another email account (an institutional email, for example) associated with a Google identity.
+1. [Set up a Terra account](https://support.terra.bio/hc/en-us/articles/360028235911-How-to-register-for-a-Terra-account) - To register for a [Terra](https://anvil.terra.bio/#workspaces) account, you will need to use an institutional email in order to access NIH controlled access data.
 
-1. [Set up Terra account with non-Google email](https://support.terra.bio/hc/en-us/articles/360029186611-Setting-up-a-Google-account-with-a-non-Google-email) - If your email is not associated with a Google identity, follow these steps to create a Google account that is associated with your non-Gmail, institutional email address.
+1. [Set up Terra account with non-Google email](https://support.terra.bio/hc/en-us/articles/360029186611-Setting-up-a-Google-account-with-a-non-Google-email) - If your email is not associated with a Google identity, follow these steps to create a Google account that is associated with your institutional email address.
 
-1. [Link your Terra and eRA Commons ID](https://support.terra.bio/hc/en-us/articles/360038086332-Linking-Terra-to-External-Servers) - To use controlled-access data on Terra, you will need to link your Terra user ID to your authorization account (such as a dbGaP account). Linking to external servers will allow Terra to automatically determine if you can access controlled datasets hosted in Terra (ex., TCGA, TOPMed, etc.) based on your approved dbGaP applications.
+1. [Link your Terra and NIH RAS ID](https://support.terra.bio/hc/en-us/articles/32634034451099-RAS-Integration-for-AnVIL-Data-Released-3-25-26) - To use controlled-access data on Terra, you will need to link your Terra user ID to your Researcher Auth Service (RAS) account. A Terra RAS account connects Terra to your authorization account (such as eRA Commons and dbGaP). Linking to external servers will allow Terra to automatically determine if you can access controlled datasets hosted in Terra (ex., TCGA, TOPMed, etc.) based on your approved dbGaP applications.
 
 Next, see [Requesting Data Access](/learn/find-data/requesting-data-access) for more information about accessing controlled access data and configuring Terra to read your data access privileges from dbGaP or your consortia access control list.

--- a/docs/learn/get-started/overview-of-account-setup.mdx
+++ b/docs/learn/get-started/overview-of-account-setup.mdx
@@ -6,7 +6,7 @@ description: "Overview of Account Setup"
 title: "Overview of Account Setup"
 ---
 
-To use AnVIL, you will need a Google account to authenticate with Terra and the AnVil Data Explorer and to associate your Terra account with a Google Cloud Platform (GCP) account.
+To use AnVIL, you will need a Google account to authenticate with Terra and the AnVIL Data Explorer and to associate your Terra account with a Google Cloud Platform (GCP) account.
 
 If you are accessing controlled-access data, you will also need an NIH RAS ID or to be a member of a data-sharing consortium.
 

--- a/docs/learn/get-started/overview-of-account-setup.mdx
+++ b/docs/learn/get-started/overview-of-account-setup.mdx
@@ -16,10 +16,10 @@ The guides below walk you through each step in the account setup process.
 
 ## Account Setup Checklist
 
-1. [Set up a Terra account](https://support.terra.bio/hc/en-us/articles/360028235911-How-to-register-for-a-Terra-account) - To register for a [Terra](https://anvil.terra.bio/#workspaces) account, you will need to use an institutional email in order to access NIH controlled access data.
+1. [Set up a Terra account](https://support.terra.bio/hc/en-us/articles/360028235911-How-to-register-for-a-Terra-account) - To register for a [Terra](https://anvil.terra.bio/#workspaces) account, you will need to use an institutional email in order to access NIH controlled-access data.
 
 1. [Set up Terra account with non-Google email](https://support.terra.bio/hc/en-us/articles/360029186611-Setting-up-a-Google-account-with-a-non-Google-email) - If your email is not associated with a Google identity, follow these steps to create a Google account that is associated with your institutional email address.
 
 1. [Link your Terra and NIH RAS ID](https://support.terra.bio/hc/en-us/articles/32634034451099-RAS-Integration-for-AnVIL-Data-Released-3-25-26) - To use controlled-access data on Terra, you will need to link your Terra user ID to your Researcher Auth Service (RAS) account. A Terra RAS account connects Terra to your authorization account (such as eRA Commons and dbGaP). Linking to external servers will allow Terra to automatically determine if you can access controlled datasets hosted in Terra (ex., TCGA, TOPMed, etc.) based on your approved dbGaP applications.
 
-Next, see [Requesting Data Access](/learn/find-data/requesting-data-access) for more information about accessing controlled access data and configuring Terra to read your data access privileges from dbGaP or your consortia access control list.
+Next, see [Requesting Data Access](/learn/find-data/requesting-data-access) for more information about accessing controlled-access data and configuring Terra to read your data access privileges from dbGaP or your consortia access control list.

--- a/docs/learn/get-started/setting-up-lab-accounts.mdx
+++ b/docs/learn/get-started/setting-up-lab-accounts.mdx
@@ -118,7 +118,7 @@ A Google ID is an email address that may be:
 - a non-Google email that has been used to create a Google Account,
 - a Google email address in Gmail, Google Workspace, or Google Identity.
 
-This email must also be the Google ID lab members will use to log in to Terra, the AnVIL Data Explorer, and associate with their ERA Commons ID for accessing controlled-access data.
+This email must also be the Google ID lab members will use to log in to Terra, the AnVIL Data Explorer, and associate with their eRA Commons ID for accessing controlled-access data.
 
 If you already have a Google ID, you can skip this step. Lab members without Google IDs can see [Create Your Google Account](https://accounts.google.com/signup/v2/webcreateaccount?flowName=GlifWebSignIn&flowEntry=SignUp) to register for a Gmail account or create an account with their current non-Google email address.
 


### PR DESCRIPTION
## Summary

Closes #4095

Updates the [Overview of Account Setup](https://anvilproject.org/learn/get-started/overview-of-account-setup) page with the revised content from the [account setup planning doc](https://docs.google.com/document/d/1PI2y_iM2ZtbJyuFtLJqi6Y2InvpkLu323fJOYJXNIWw/edit) (source of truth for the copy):

- Replaced eRA Commons ID references with NIH RAS ID in the intro paragraphs
- Retitled the third checklist item to "Link your Terra and NIH RAS ID" and revised its description per the doc
- Updated the third item's link from the old external-servers article to Terra's newer RAS-specific article ([RAS Integration for AnVIL Data - Released 3/25/26](https://support.terra.bio/hc/en-us/articles/32634034451099-RAS-Integration-for-AnVIL-Data-Released-3-25-26)) — verified live
- Updated checklist items 1 and 2 wording (institutional email requirement for NIH controlled-access data)
- One deviation from the doc: "ERA Commons" corrected to the official styling "eRA Commons"

Verified locally: page renders correctly on the dev server; lint, prettier, and dev build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2559" height="1134" alt="image" src="https://github.com/user-attachments/assets/7f1c5e51-ae46-4ff5-b90f-1c0e111107b4" />
