### PR TITLE
content: add biodata ascent event (#4094)

### DIFF
--- a/docs/events/biodata-ascent2026-code-a-thon.mdx
+++ b/docs/events/biodata-ascent2026-code-a-thon.mdx
@@ -31,8 +31,6 @@ Brought to you by the [Common Fund Data Ecosystem (CFDE)](https://commonfund.nih
 
 Participants with a range of biological and computational backgrounds are welcome; no prior cloud-computing or AI experience is required.
 
-Register for the BioDATA ASCENT code-a-thon on the [Biological Data Science Conference Website](https://meetings.cshl.edu/meetings.aspx?meet=DATA&year=26). Make sure to request housing for November 3rd for the start of the code-a-thon.
-
 ## Event Details
 
 - Event page: https://biodata-ascent.github.io/

--- a/docs/events/biodata-ascent2026-code-a-thon.mdx
+++ b/docs/events/biodata-ascent2026-code-a-thon.mdx
@@ -1,0 +1,41 @@
+---
+conference: "BioDATA ASCENT"
+description: "A hands-on code-a-thon where early-career researchers use cloud computing, AI, and large-scale biological and biomedical data to turn interesting biological questions into working analyses."
+eventType: "Code-A-Thon"
+featured: true
+location: "Cold Spring Harbor Laboratory"
+sessions:
+  [
+    {
+      sessionStart: "3 November 2026 7:00 PM",
+      sessionEnd: "3 November 2026 9:00 PM",
+    },
+    {
+      sessionStart: "4 November 2026 9:00 AM",
+      sessionEnd: "4 November 2026 5:00 PM",
+    },
+  ]
+timezone: "America/New_York"
+title: "BioDATA ASCENT Code-A-Thon"
+---
+
+<EventsHero {...frontmatter} />
+
+Join the BioDATA ASCENT code-a-thon, an intensive, hands-on event where early-career researchers use cloud computing, AI, and large-scale biological and biomedical data to turn interesting biological questions into working analyses.
+
+Hosted by [Allissa Dillman](https://www.biodatasage.com/about) (BioDataSage) and [Michael Schatz](http://schatz-lab.org/) (JHU) immediately before the 2026 CSHL [Biological Data Science Conference](https://meetings.cshl.edu/meetings.aspx?meet=DATA&year=26), this collaborative code-a-thon is designed especially for PhD students and postdocs. You’ll work in small teams alongside peers and mentors to explore real NIH-supported datasets, learn practical computational skills, and build something tangible: a prototype, analysis, reusable workflow, visualization, or next-step plan for a research project.
+
+Brought to you by the [Common Fund Data Ecosystem (CFDE)](https://commonfund.nih.gov/dataecosystem) and the [NHGRI AnVIL](/) programs, ASCENT brings together AI, Science, Cloud, Exploration, Networks, and Technology. No fully formed project is required: bring a scientific question, a technical skill, an early idea, or simply curiosity and a willingness to collaborate.
+
+## Prerequisites
+
+Participants with a range of biological and computational backgrounds are welcome; no prior cloud-computing or AI experience is required.
+
+Register for the BioDATA ASCENT code-a-thon on the [Biological Data Science Conference Website](https://meetings.cshl.edu/meetings.aspx?meet=DATA&year=26). Make sure to request housing for November 3rd for the start of the code-a-thon.
+
+## Event Details
+
+- Event page: https://biodata-ascent.github.io/
+- [Agenda](https://biodata-ascent.github.io/#schedule)
+- How to register: Register for the BioDATA ASCENT code-a-thon on the [Biological Data Science Conference Website](https://meetings.cshl.edu/meetings.aspx?meet=DATA&year=26). Make sure to request housing for November 3rd for the start of the code-a-thon.
+- Costs: CSHL Biological Data Science Conference registration plus $255.00 USD for additional night of lodging at CSHL.

--- a/docs/events/biodata-ascent2026-code-a-thon.mdx
+++ b/docs/events/biodata-ascent2026-code-a-thon.mdx
@@ -1,5 +1,5 @@
 ---
-conference: "BioDATA ASCENT 2026"
+conference: "CSHL Biological Data Science 2026"
 description: "A hands-on code-a-thon where early-career researchers use cloud computing, AI, and large-scale biological and biomedical data to turn interesting biological questions into working analyses."
 eventType: "Code-A-Thon"
 featured: true

--- a/docs/events/biodata-ascent2026-code-a-thon.mdx
+++ b/docs/events/biodata-ascent2026-code-a-thon.mdx
@@ -3,7 +3,7 @@ conference: "CSHL Biological Data Science 2026"
 description: "A hands-on code-a-thon where early-career researchers use cloud computing, AI, and large-scale biological and biomedical data to turn interesting biological questions into working analyses."
 eventType: "Code-A-Thon"
 featured: true
-location: "Cold Spring Harbor Laboratory"
+location: "Cold Spring Harbor, NY, USA"
 sessions:
   [
     {
@@ -34,6 +34,6 @@ Participants with a range of biological and computational backgrounds are welcom
 ## Event Details
 
 - Event page: https://biodata-ascent.github.io/
-- [Agenda](https://biodata-ascent.github.io/#schedule)
+- Agenda: https://biodata-ascent.github.io/#schedule
 - How to register: Register for the BioDATA ASCENT code-a-thon on the [Biological Data Science Conference Website](https://meetings.cshl.edu/meetings.aspx?meet=DATA&year=26). Make sure to request housing for November 3rd for the start of the code-a-thon.
 - Costs: CSHL Biological Data Science Conference registration plus $255.00 USD for additional night of lodging at CSHL.

--- a/docs/events/biodata-ascent2026-code-a-thon.mdx
+++ b/docs/events/biodata-ascent2026-code-a-thon.mdx
@@ -1,5 +1,5 @@
 ---
-conference: "BioDATA ASCENT"
+conference: "BioDATA ASCENT 2026"
 description: "A hands-on code-a-thon where early-career researchers use cloud computing, AI, and large-scale biological and biomedical data to turn interesting biological questions into working analyses."
 eventType: "Code-A-Thon"
 featured: true
@@ -23,7 +23,7 @@ title: "BioDATA ASCENT Code-A-Thon"
 
 Join the BioDATA ASCENT code-a-thon, an intensive, hands-on event where early-career researchers use cloud computing, AI, and large-scale biological and biomedical data to turn interesting biological questions into working analyses.
 
-Hosted by [Allissa Dillman](https://www.biodatasage.com/about) (BioDataSage) and [Michael Schatz](http://schatz-lab.org/) (JHU) immediately before the 2026 CSHL [Biological Data Science Conference](https://meetings.cshl.edu/meetings.aspx?meet=DATA&year=26), this collaborative code-a-thon is designed especially for PhD students and postdocs. You’ll work in small teams alongside peers and mentors to explore real NIH-supported datasets, learn practical computational skills, and build something tangible: a prototype, analysis, reusable workflow, visualization, or next-step plan for a research project.
+Hosted by [Allissa Dillman](https://www.biodatasage.com/about) (BioDataSage) and [Michael Schatz](https://schatz-lab.org/) (JHU) immediately before the 2026 CSHL [Biological Data Science Conference](https://meetings.cshl.edu/meetings.aspx?meet=DATA&year=26), this collaborative code-a-thon is designed especially for PhD students and postdocs. You’ll work in small teams alongside peers and mentors to explore real NIH-supported datasets, learn practical computational skills, and build something tangible: a prototype, analysis, reusable workflow, visualization, or next-step plan for a research project.
 
 Brought to you by the [Common Fund Data Ecosystem (CFDE)](https://commonfund.nih.gov/dataecosystem) and the [NHGRI AnVIL](/) programs, ASCENT brings together AI, Science, Cloud, Exploration, Networks, and Technology. No fully formed project is required: bring a scientific question, a technical skill, an early idea, or simply curiosity and a willingness to collaborate.
 


### PR DESCRIPTION
## Summary

Closes #4094

Adds the BioDATA ASCENT Code-A-Thon event page (`/events/biodata-ascent2026-code-a-thon`) from the event submission in #4094:

- Two sessions: November 3, 2026 7:00–9:00 PM ET and November 4, 2026 9:00 AM–5:00 PM ET, at Cold Spring Harbor Laboratory
- Event text, prerequisites, and event details (event page, agenda, registration, costs) taken from the issue
- Short description (the issue left it blank) written from the event text, under the 200-character limit
- `featured: true` so the event appears in the home page events list
- The NHGRI AnVIL link uses a relative `/` so it stays in-app rather than opening a new tab

Verified locally: event detail page and the /events upcoming list render correctly on the dev server; lint, prettier, and dev build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2559" height="1234" alt="image" src="https://github.com/user-attachments/assets/5d265b94-8ef9-4c71-8046-581a926da663" />
