### PR TITLE
content: update gmail-recommending get-started pages to match institutional-email guidance (#4105)

### DIFF
--- a/docs/learn/get-started/creating-a-terra-account.mdx
+++ b/docs/learn/get-started/creating-a-terra-account.mdx
@@ -6,7 +6,7 @@ description: ""
 title: "Creating a Terra Account"
 ---
 
-To register for a Terra account, you will need a Gmail account or another email account (an institutional email, for example) associated with a Google identity for SSO. See [Obtaining a Google Id](/learn/get-started/obtaining-a-google-id) for instructions on creating a Google ID.
+To register for a Terra account, you will need your **institutional email address** associated with a Google identity for SSO. Do not use a personal webmail address such as Gmail, Yahoo, Hotmail, outlook.com, etc. — an institutional email is required to access NIH controlled-access data. See [Obtaining a Google ID](/learn/get-started/obtaining-a-google-id) for instructions on creating a Google ID.
 
 See [Set up a Terra account](https://support.terra.bio/hc/en-us/articles/360028235911-How-to-register-for-a-Terra-account) for instructions on setting up your Terra account.
 

--- a/docs/learn/get-started/obtaining-a-google-id.mdx
+++ b/docs/learn/get-started/obtaining-a-google-id.mdx
@@ -8,9 +8,9 @@ title: "Obtaining a Google ID"
 
 A Google ID is a Google level resource required to create GCP and Terra accounts.
 
-A Google ID is simply an email address. This email address must be either: a non Google email address that you have associated with a Google Account or a Gmail, Google Workspace (formerly G Suite), or Google Identity email address.
+A Google ID is simply an email address that is associated with a Google Account. This can be a non-Google email address that you have associated with a Google Account, or a Google Workspace (formerly G Suite) or Google Identity email address.
 
-If you do not have a Google ID and wish to create one, register for a Gmail account or create an account with your non-Google email address.
+If you do not have a Google ID and wish to create one, create a Google Account using your **institutional email address**. An institutional email is required to access NIH controlled-access data; do not use a personal webmail address such as Gmail, Yahoo, Hotmail, outlook.com, etc.
 
 <CallToActionButton callToAction={{ label: "Create Your Google Account", url: "https://accounts.google.com/signup/v2/webcreateaccount?flowName=GlifWebSignIn&flowEntry=SignUp" }} />
 


### PR DESCRIPTION
## Summary

Closes #4105

Aligns the two remaining Gmail-recommending Getting Started pages with the institutional-email guidance adopted in #4097 and the warning on the requesting-data-access page:

- **creating-a-terra-account.mdx** — the opening sentence now leads with the institutional email requirement and warns against personal webmail addresses (Gmail, Yahoo, Hotmail, outlook.com, etc.), noting an institutional email is required for NIH controlled-access data; also fixes the "Obtaining a Google Id" link casing
- **obtaining-a-google-id.mdx** — replaces "register for a Gmail account" with creating a Google Account using your institutional email address, with the same personal-webmail warning; the "Create Your Google Account" CTA and the "Use my current email address instead" alert are unchanged and still apply

Out of scope but noted while sweeping: `setting-up-lab-accounts.mdx:123` and `billing-concepts.mdx:17` contain similar Gmail-first phrasing and may warrant a follow-up.

## Verification

- `npm run lint`, `npm run check-format`, and `npm run build-dev:anvil-portal` all pass
- Visually verified both built pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2390" height="1101" alt="image" src="https://github.com/user-attachments/assets/639ed978-8cdb-4d60-987d-d1d8657a8f36" />

<img width="2386" height="1216" alt="image" src="https://github.com/user-attachments/assets/f4b6a697-5a3d-4c85-b727-b07280092a20" />
