### PR TITLE
chore: scope stale 'change these values' banner in analytics constants (#4103)

### DIFF
--- a/analytics/constants.py
+++ b/analytics/constants.py
@@ -1,6 +1,8 @@
-# CHANGE THESE VALUES TO GENERATE NEW REPORTS
+# CHANGE THIS VALUE TO GENERATE A NEW REPORT
 # The date of the current month to report on (yyyy-mm)
 CURRENT_MONTH = "2026-07"
+
+# FIXED CONFIGURATION — the values below do not change between monthly reports
 
 ANVIL_PORTAL_ID = "368678391"
 


### PR DESCRIPTION
## Summary

Closes #4103

- Singularizes the stale plural banner in `analytics/constants.py` to `# CHANGE THIS VALUE TO GENERATE A NEW REPORT`, scoping it to `CURRENT_MONTH` — the only per-report knob since #4096
- Adds a `# FIXED CONFIGURATION` separator so the infrastructure values below (`ANVIL_PORTAL_ID`, `EXCLUDE_BOT_TRAFFIC_DATES`, `SECRET_NAME`, etc.) are clearly not monthly-edited

## Verification

- Python syntax verified (`ast.parse`); comment-only change, so lint and the Next.js build don't apply to this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)